### PR TITLE
feat: Redeem tokens from contract

### DIFF
--- a/components/lsp-form/Collateral.tsx
+++ b/components/lsp-form/Collateral.tsx
@@ -23,6 +23,7 @@ interface Props {
   collateralOnTop?: boolean;
   collateralBalance: ethers.BigNumber;
   collateralPerPair: ethers.BigNumber;
+  // Note: Long/Short tokens are always the same as the collateral. Enforced on contract.
   collateralDecimals: string;
   setLongTokenAmount: React.Dispatch<React.SetStateAction<string>>;
   setShortTokenAmount: React.Dispatch<React.SetStateAction<string>>;

--- a/components/lsp-form/Collateral.tsx
+++ b/components/lsp-form/Collateral.tsx
@@ -73,12 +73,6 @@ const Collateral: FC<Props> = ({
           additionalEffects={(e) => {
             if (e.target.value) {
               const value = e.target.value;
-
-              // // test if the regexp is a float.
-              // const floatRegExp = /^[0-9]\d*(\.\d+)?$/;
-              // if (!floatRegExp.test(value)) {
-              //   return false;
-              // }
               setLongShortPairInputs(value);
             } else {
               setLongTokenAmount("0");

--- a/components/lsp-form/Collateral.tsx
+++ b/components/lsp-form/Collateral.tsx
@@ -11,6 +11,7 @@ import TextInput from "../text-input";
 import { LabelPlacement } from "../text-input/TextInput";
 import useWindowSize from "../../hooks/useWindowSize";
 import { ethers } from "ethers";
+import { onlyAllowNumbersAndDecimals } from "./helpers";
 
 interface Props {
   collateral: string;
@@ -71,12 +72,20 @@ const Collateral: FC<Props> = ({
           width={width}
           additionalEffects={(e) => {
             if (e.target.value) {
-              setLongShortPairInputs(e.target.value);
+              const value = e.target.value;
+
+              // // test if the regexp is a float.
+              // const floatRegExp = /^[0-9]\d*(\.\d+)?$/;
+              // if (!floatRegExp.test(value)) {
+              //   return false;
+              // }
+              setLongShortPairInputs(value);
             } else {
               setLongTokenAmount("0");
               setShortTokenAmount("0");
             }
           }}
+          onKeyDown={onlyAllowNumbersAndDecimals}
         />
       </FormRow>
       <BalanceRow>

--- a/components/lsp-form/Collateral.tsx
+++ b/components/lsp-form/Collateral.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useCallback } from "react";
 import {
   FormRow,
   BalanceRow,
@@ -41,6 +41,19 @@ const Collateral: FC<Props> = ({
 }) => {
   const size = useWindowSize();
   const width = size.width && size.width > 728 ? "230px" : "100%";
+
+  const setLongShortPair = useCallback(
+    (collateral) => {
+      const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
+
+      const newTokenPairAmounts = Number(collateral) / Number(normalizedCPP);
+
+      setLongTokenAmount(newTokenPairAmounts.toString());
+      setShortTokenAmount(newTokenPairAmounts.toString());
+    },
+    [collateralPerPair]
+  );
+
   return (
     <>
       <FormRow>
@@ -58,12 +71,7 @@ const Collateral: FC<Props> = ({
           width={width}
           additionalEffects={(e) => {
             if (e.target.value) {
-              const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
-              const newTokenPairAmounts =
-                Number(e.target.value) / Number(normalizedCPP);
-
-              setLongTokenAmount(newTokenPairAmounts.toString());
-              setShortTokenAmount(newTokenPairAmounts.toString());
+              setLongShortPair(e.target.value);
             } else {
               setLongTokenAmount("0");
               setShortTokenAmount("0");
@@ -80,7 +88,19 @@ const Collateral: FC<Props> = ({
               collateralDecimals
             )}
           </span>{" "}
-          {(collateralOnTop || !redeemForm) && <span>Max</span>}
+          {(collateralOnTop || !redeemForm) && (
+            <span
+              onClick={() => {
+                const normalizedBalance =
+                  ethers.utils.formatEther(collateralBalance);
+                setAmount(normalizedBalance);
+
+                setLongShortPair(normalizedBalance);
+              }}
+            >
+              Max
+            </span>
+          )}
         </div>
       </BalanceRow>
     </>

--- a/components/lsp-form/Collateral.tsx
+++ b/components/lsp-form/Collateral.tsx
@@ -42,8 +42,8 @@ const Collateral: FC<Props> = ({
   const size = useWindowSize();
   const width = size.width && size.width > 728 ? "230px" : "100%";
 
-  const setLongShortPair = useCallback(
-    (collateral) => {
+  const setLongShortPairInputs = useCallback(
+    (collateral: string) => {
       const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
 
       const newTokenPairAmounts = Number(collateral) / Number(normalizedCPP);
@@ -71,7 +71,7 @@ const Collateral: FC<Props> = ({
           width={width}
           additionalEffects={(e) => {
             if (e.target.value) {
-              setLongShortPair(e.target.value);
+              setLongShortPairInputs(e.target.value);
             } else {
               setLongTokenAmount("0");
               setShortTokenAmount("0");
@@ -95,7 +95,7 @@ const Collateral: FC<Props> = ({
                   ethers.utils.formatEther(collateralBalance);
                 setAmount(normalizedBalance);
 
-                setLongShortPair(normalizedBalance);
+                setLongShortPairInputs(normalizedBalance);
               }}
             >
               Max

--- a/components/lsp-form/LSPForm.tsx
+++ b/components/lsp-form/LSPForm.tsx
@@ -20,6 +20,7 @@ interface Props {
   collateralBalance: ethers.BigNumber;
   collateralPerPair: ethers.BigNumber;
   setCollateralBalance: React.Dispatch<React.SetStateAction<ethers.BigNumber>>;
+  // Note: Long/Short tokens are always the same as the collateral. Enforced on contract.
   collateralDecimals: string;
   longTokenBalance: ethers.BigNumber;
   shortTokenBalance: ethers.BigNumber;

--- a/components/lsp-form/LSPForm.tsx
+++ b/components/lsp-form/LSPForm.tsx
@@ -81,6 +81,8 @@ const LSPForm: FC<Props> = ({
               longTokenDecimals={longTokenDecimals}
               shortTokenBalance={shortTokenBalance}
               shortTokenDecimals={shortTokenDecimals}
+              lspContract={lspContract}
+              erc20Contract={erc20Contract}
             />
           </div>
         </Tabs>

--- a/components/lsp-form/LSPForm.tsx
+++ b/components/lsp-form/LSPForm.tsx
@@ -22,9 +22,7 @@ interface Props {
   setCollateralBalance: React.Dispatch<React.SetStateAction<ethers.BigNumber>>;
   collateralDecimals: string;
   longTokenBalance: ethers.BigNumber;
-  longTokenDecimals: string;
   shortTokenBalance: ethers.BigNumber;
-  shortTokenDecimals: string;
   refetchLongTokenBalance: () => void;
   refetchShortTokenBalance: () => void;
 }
@@ -40,9 +38,7 @@ const LSPForm: FC<Props> = ({
   setCollateralBalance,
   collateralDecimals,
   longTokenBalance,
-  longTokenDecimals,
   shortTokenBalance,
-  shortTokenDecimals,
   refetchLongTokenBalance,
   refetchShortTokenBalance,
 }) => {
@@ -65,9 +61,7 @@ const LSPForm: FC<Props> = ({
               setCollateralBalance={setCollateralBalance}
               collateralDecimals={collateralDecimals}
               longTokenBalance={longTokenBalance}
-              longTokenDecimals={longTokenDecimals}
               shortTokenBalance={shortTokenBalance}
-              shortTokenDecimals={shortTokenDecimals}
               refetchLongTokenBalance={refetchLongTokenBalance}
               refetchShortTokenBalance={refetchShortTokenBalance}
             />
@@ -78,9 +72,7 @@ const LSPForm: FC<Props> = ({
               collateralPerPair={collateralPerPair}
               collateralDecimals={collateralDecimals}
               longTokenBalance={longTokenBalance}
-              longTokenDecimals={longTokenDecimals}
               shortTokenBalance={shortTokenBalance}
-              shortTokenDecimals={shortTokenDecimals}
               lspContract={lspContract}
               erc20Contract={erc20Contract}
               address={address}

--- a/components/lsp-form/LSPForm.tsx
+++ b/components/lsp-form/LSPForm.tsx
@@ -83,6 +83,10 @@ const LSPForm: FC<Props> = ({
               shortTokenDecimals={shortTokenDecimals}
               lspContract={lspContract}
               erc20Contract={erc20Contract}
+              address={address}
+              setCollateralBalance={setCollateralBalance}
+              refetchLongTokenBalance={refetchLongTokenBalance}
+              refetchShortTokenBalance={refetchShortTokenBalance}
             />
           </div>
         </Tabs>

--- a/components/lsp-form/LongShort.tsx
+++ b/components/lsp-form/LongShort.tsx
@@ -54,13 +54,11 @@ const LongShort: FC<Props> = ({
   const maxTokensRedeemable = useCallback(() => {
     const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
 
-    let ltb = "0",
-      stb = "0",
+    let ltbStb = "0",
       am = "0";
 
     if (longTokenBalance.gte(shortTokenBalance)) {
-      ltb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
-      stb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
+      ltbStb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
       am = (
         Number(
           ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals)
@@ -69,8 +67,7 @@ const LongShort: FC<Props> = ({
     }
 
     if (longTokenBalance.lt(shortTokenBalance)) {
-      ltb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
-      stb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
+      ltbStb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
       am = (
         Number(
           ethers.utils.formatUnits(
@@ -81,10 +78,10 @@ const LongShort: FC<Props> = ({
       ).toString();
     }
 
-    setShortTokenAmount(stb);
-    setLongTokenAmount(ltb);
+    setShortTokenAmount(ltbStb);
+    setLongTokenAmount(ltbStb);
     setAmount(am);
-  }, []);
+  }, [longTokenBalance, shortTokenBalance, collateralPerPair]);
 
   return (
     <>

--- a/components/lsp-form/LongShort.tsx
+++ b/components/lsp-form/LongShort.tsx
@@ -51,10 +51,11 @@ const LongShort: FC<Props> = ({
   );
 
   const maxTokensRedeemable = useCallback(() => {
+    const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
+
     let ltb = "0",
       stb = "0",
       am = "0";
-    const normalizedCPP = ethers.utils.formatEther(collateralPerPair);
 
     if (
       longTokenBalance.gt(shortTokenBalance) ||
@@ -70,10 +71,15 @@ const LongShort: FC<Props> = ({
     }
 
     if (longTokenBalance.lt(shortTokenBalance)) {
-      ltb = longTokenBalance.toString();
-      stb = longTokenBalance.toString();
+      ltb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
+      stb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
       am = (
-        Number(longTokenBalance.toString()) * Number(normalizedCPP)
+        Number(
+          ethers.utils.formatUnits(
+            Number(longTokenBalance.toString()) * Number(normalizedCPP),
+            longTokenDecimals
+          )
+        ) * Number(normalizedCPP)
       ).toString();
     }
 
@@ -81,8 +87,6 @@ const LongShort: FC<Props> = ({
     setLongTokenAmount(ltb);
     setAmount(am);
   }, []);
-
-  console.log("coll", collateralOnTop);
 
   return (
     <>

--- a/components/lsp-form/LongShort.tsx
+++ b/components/lsp-form/LongShort.tsx
@@ -4,6 +4,7 @@ import { FormRow, BalanceRowToken } from "./LSPForm.styled";
 import TextInput from "../text-input";
 import { LabelPlacement } from "../text-input/TextInput";
 import { ethers } from "ethers";
+import { onlyAllowNumbersAndDecimals } from "./helpers";
 
 interface Props {
   setAmount: React.Dispatch<React.SetStateAction<string>>;
@@ -105,6 +106,7 @@ const LongShort: FC<Props> = ({
               setAmount("0");
             }
           }}
+          onKeyDown={onlyAllowNumbersAndDecimals}
         />
         <TextInput
           label="short token"
@@ -120,6 +122,7 @@ const LongShort: FC<Props> = ({
               setLongTokenAmount("0");
             }
           }}
+          onKeyDown={onlyAllowNumbersAndDecimals}
         />
       </FormRow>
       <BalanceRowToken>

--- a/components/lsp-form/LongShort.tsx
+++ b/components/lsp-form/LongShort.tsx
@@ -17,9 +17,9 @@ interface Props {
   collateralOnTop?: boolean;
   collateralPerPair: ethers.BigNumber;
   longTokenBalance: ethers.BigNumber;
-  longTokenDecimals: string;
   shortTokenBalance: ethers.BigNumber;
-  shortTokenDecimals: string;
+  // Note: Long/Short tokens are always the same as the collateral. Enforced on contract.
+  collateralDecimals: string;
 }
 
 const LongShort: FC<Props> = ({
@@ -32,9 +32,8 @@ const LongShort: FC<Props> = ({
   setAmount,
   collateralPerPair,
   longTokenBalance,
-  longTokenDecimals,
   shortTokenBalance,
-  shortTokenDecimals,
+  collateralDecimals,
 }) => {
   const setCollateralInput = useCallback(
     (
@@ -58,21 +57,21 @@ const LongShort: FC<Props> = ({
       am = "0";
 
     if (longTokenBalance.gte(shortTokenBalance)) {
-      ltbStb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
+      ltbStb = ethers.utils.formatUnits(shortTokenBalance, collateralDecimals);
       am = (
         Number(
-          ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals)
+          ethers.utils.formatUnits(shortTokenBalance, collateralDecimals)
         ) * Number(normalizedCPP)
       ).toString();
     }
 
     if (longTokenBalance.lt(shortTokenBalance)) {
-      ltbStb = ethers.utils.formatUnits(longTokenBalance, longTokenDecimals);
+      ltbStb = ethers.utils.formatUnits(longTokenBalance, collateralDecimals);
       am = (
         Number(
           ethers.utils.formatUnits(
             Number(longTokenBalance.toString()) * Number(normalizedCPP),
-            longTokenDecimals
+            collateralDecimals
           )
         ) * Number(normalizedCPP)
       ).toString();
@@ -125,7 +124,7 @@ const LongShort: FC<Props> = ({
             Your Balance{" "}
             {ethers.utils.formatUnits(
               longTokenBalance.toString(),
-              longTokenDecimals
+              collateralDecimals
             )}{" "}
           </span>
           {!collateralOnTop && redeemForm && (
@@ -143,7 +142,7 @@ const LongShort: FC<Props> = ({
             Your Balance{" "}
             {ethers.utils.formatUnits(
               shortTokenBalance.toString(),
-              shortTokenDecimals
+              collateralDecimals
             )}
           </span>
           {!collateralOnTop && redeemForm && (

--- a/components/lsp-form/LongShort.tsx
+++ b/components/lsp-form/LongShort.tsx
@@ -58,10 +58,7 @@ const LongShort: FC<Props> = ({
       stb = "0",
       am = "0";
 
-    if (
-      longTokenBalance.gt(shortTokenBalance) ||
-      longTokenBalance.eq(shortTokenBalance)
-    ) {
+    if (longTokenBalance.gte(shortTokenBalance)) {
       ltb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
       stb = ethers.utils.formatUnits(shortTokenBalance, shortTokenDecimals);
       am = (

--- a/components/lsp-form/MintForm.tsx
+++ b/components/lsp-form/MintForm.tsx
@@ -136,9 +136,8 @@ const MintForm: FC<Props> = ({
           setShortTokenAmount={setShortTokenAmount}
           collateralPerPair={collateralPerPair}
           longTokenBalance={longTokenBalance}
-          longTokenDecimals={longTokenDecimals}
           shortTokenBalance={shortTokenBalance}
-          shortTokenDecimals={shortTokenDecimals}
+          collateralDecimals={collateralDecimals}
         />
       </BottomFormWrapper>
       <ButtonWrapper>

--- a/components/lsp-form/MintForm.tsx
+++ b/components/lsp-form/MintForm.tsx
@@ -32,6 +32,7 @@ interface Props {
   collateralBalance: ethers.BigNumber;
   collateralPerPair: ethers.BigNumber;
   setCollateralBalance: React.Dispatch<React.SetStateAction<ethers.BigNumber>>;
+  // Note: Long/Short tokens are always the same as the collateral. Enforced on contract.
   collateralDecimals: string;
   longTokenBalance: ethers.BigNumber;
   shortTokenBalance: ethers.BigNumber;

--- a/components/lsp-form/MintForm.tsx
+++ b/components/lsp-form/MintForm.tsx
@@ -34,9 +34,7 @@ interface Props {
   setCollateralBalance: React.Dispatch<React.SetStateAction<ethers.BigNumber>>;
   collateralDecimals: string;
   longTokenBalance: ethers.BigNumber;
-  longTokenDecimals: string;
   shortTokenBalance: ethers.BigNumber;
-  shortTokenDecimals: string;
   refetchLongTokenBalance: () => void;
   refetchShortTokenBalance: () => void;
 }
@@ -51,9 +49,7 @@ const MintForm: FC<Props> = ({
   setCollateralBalance,
   collateralDecimals,
   longTokenBalance,
-  longTokenDecimals,
   shortTokenBalance,
-  shortTokenDecimals,
   refetchLongTokenBalance,
   refetchShortTokenBalance,
 }) => {
@@ -87,12 +83,12 @@ const MintForm: FC<Props> = ({
         lspContract
           .create(mintAmount)
           .then((tx: any) => {
-            return tx.wait(1);
-          })
-          .then(async () => {
             setAmount("");
             setLongTokenAmount("");
             setShortTokenAmount("");
+            return tx.wait(1);
+          })
+          .then(async () => {
             const balance = (await erc20Contract.balanceOf(
               address
             )) as ethers.BigNumber;

--- a/components/lsp-form/RedeemForm.tsx
+++ b/components/lsp-form/RedeemForm.tsx
@@ -68,6 +68,7 @@ const RedeemForm: FC<Props> = ({
             longTokenDecimals={longTokenDecimals}
             shortTokenBalance={shortTokenBalance}
             shortTokenDecimals={shortTokenDecimals}
+            collateralOnTop={collateralOnTop}
           />
         )}
       </TopFormWrapper>
@@ -92,6 +93,7 @@ const RedeemForm: FC<Props> = ({
             longTokenDecimals={longTokenDecimals}
             shortTokenBalance={shortTokenBalance}
             shortTokenDecimals={shortTokenDecimals}
+            collateralOnTop={collateralOnTop}
           />
         ) : (
           <Collateral
@@ -105,6 +107,7 @@ const RedeemForm: FC<Props> = ({
             setLongTokenAmount={setLongTokenAmount}
             setShortTokenAmount={setShortTokenAmount}
             redeemForm
+            collateralOnTop={collateralOnTop}
           />
         )}
       </BottomFormWrapper>

--- a/components/lsp-form/RedeemForm.tsx
+++ b/components/lsp-form/RedeemForm.tsx
@@ -31,7 +31,7 @@ const RedeemForm: FC<Props> = ({
   shortTokenBalance,
   shortTokenDecimals,
 }) => {
-  const [collateral, setCollateral] = useState("");
+  const [collateral, setCollateral] = useState("uma");
   const [amount, setAmount] = useState("");
   const [longTokenAmount, setLongTokenAmount] = useState("");
   const [shortTokenAmount, setShortTokenAmount] = useState("");

--- a/components/lsp-form/RedeemForm.tsx
+++ b/components/lsp-form/RedeemForm.tsx
@@ -37,9 +37,7 @@ const RedeemForm: FC<Props> = ({
   collateralPerPair,
   collateralDecimals,
   longTokenBalance,
-  longTokenDecimals,
   shortTokenBalance,
-  shortTokenDecimals,
   lspContract,
   erc20Contract,
   address,
@@ -64,15 +62,15 @@ const RedeemForm: FC<Props> = ({
         // User has specified in the input.
         // All operations that make the number larger come first. All the operations that make the number smaller come last.
         const redeemAmount = weiAmount.mul(scaledToWei);
-        lspContract
+        await lspContract
           .redeem(redeemAmount.div(scaledToWei))
           .then((tx: any) => {
-            return tx.wait(1);
-          })
-          .then(async () => {
             setAmount("");
             setLongTokenAmount("");
             setShortTokenAmount("");
+            return tx.wait(1);
+          })
+          .then(async () => {
             const balance = (await erc20Contract.balanceOf(
               address
             )) as ethers.BigNumber;
@@ -114,10 +112,9 @@ const RedeemForm: FC<Props> = ({
             setShortTokenAmount={setShortTokenAmount}
             collateralPerPair={collateralPerPair}
             longTokenBalance={longTokenBalance}
-            longTokenDecimals={longTokenDecimals}
             shortTokenBalance={shortTokenBalance}
-            shortTokenDecimals={shortTokenDecimals}
             collateralOnTop={collateralOnTop}
+            collateralDecimals={collateralDecimals}
           />
         )}
       </TopFormWrapper>
@@ -139,10 +136,9 @@ const RedeemForm: FC<Props> = ({
             setShortTokenAmount={setShortTokenAmount}
             collateralPerPair={collateralPerPair}
             longTokenBalance={longTokenBalance}
-            longTokenDecimals={longTokenDecimals}
             shortTokenBalance={shortTokenBalance}
-            shortTokenDecimals={shortTokenDecimals}
             collateralOnTop={collateralOnTop}
+            collateralDecimals={collateralDecimals}
           />
         ) : (
           <Collateral

--- a/components/lsp-form/RedeemForm.tsx
+++ b/components/lsp-form/RedeemForm.tsx
@@ -64,7 +64,6 @@ const RedeemForm: FC<Props> = ({
         // User has specified in the input.
         // All operations that make the number larger come first. All the operations that make the number smaller come last.
         const redeemAmount = weiAmount.mul(scaledToWei);
-        // console.log("redeemAmount", redeemAmount);
         lspContract
           .redeem(redeemAmount.div(scaledToWei))
           .then((tx: any) => {

--- a/components/lsp-form/RedeemForm.tsx
+++ b/components/lsp-form/RedeemForm.tsx
@@ -21,9 +21,7 @@ interface Props {
   collateralPerPair: ethers.BigNumber;
   collateralDecimals: string;
   longTokenBalance: ethers.BigNumber;
-  longTokenDecimals: string;
   shortTokenBalance: ethers.BigNumber;
-  shortTokenDecimals: string;
   lspContract: ethers.Contract | null;
   erc20Contract: ethers.Contract | null;
   address: string;

--- a/components/lsp-form/helpers.ts
+++ b/components/lsp-form/helpers.ts
@@ -26,7 +26,9 @@ export const onlyAllowNumbersAndDecimals = (
     // Allow copy paste
     (event.metaKey && event.key === "v") ||
     // Allow undo
-    (event.metaKey && event.key === "z")
+    (event.metaKey && event.key === "z") ||
+    // Allow cut
+    (event.metaKey && event.key === "x")
   ) {
     return true;
   } else {

--- a/components/lsp-form/helpers.ts
+++ b/components/lsp-form/helpers.ts
@@ -22,12 +22,14 @@ export const onlyAllowNumbersAndDecimals = (
     Number(event.key) >= 0 ||
     event.key === "." ||
     event.key === "Backspace" ||
-    event.key === "Tab"
+    event.key === "Tab" ||
+    // Allow copy paste
+    (event.metaKey && event.key === "v") ||
+    // Allow undo
+    (event.metaKey && event.key === "z")
   ) {
     return true;
   } else {
-    if (event.metaKey && event.key === "v") return true;
-
     event.preventDefault();
 
     return false;

--- a/components/lsp-form/helpers.ts
+++ b/components/lsp-form/helpers.ts
@@ -11,3 +11,25 @@ export const calculateTimeRemaining = () => {
 
   return text;
 };
+
+// Only permits numbers and decimals
+// This is intended for a keydown or keyup event handler.
+// Tab, Backspace, and copy+paste also goes through.
+export const onlyAllowNumbersAndDecimals = (
+  event: React.KeyboardEvent<HTMLInputElement>
+) => {
+  if (
+    Number(event.key) >= 0 ||
+    event.key === "." ||
+    event.key === "Backspace" ||
+    event.key === "Tab"
+  ) {
+    return true;
+  } else {
+    if (event.metaKey && event.key === "v") return true;
+
+    event.preventDefault();
+
+    return false;
+  }
+};

--- a/components/text-input/TextInput.tsx
+++ b/components/text-input/TextInput.tsx
@@ -11,6 +11,7 @@ interface Props {
   // Optional arg: If there is some side effect of the change to the input
   // Pass in this function and it will run when the value changes
   additionalEffects?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement> | undefined;
 }
 
 export type LabelPlacement = "default | overlap";
@@ -22,6 +23,7 @@ const TextInput: FC<Props> = ({
   labelPlacement = "default" as LabelPlacement,
   width,
   additionalEffects,
+  onKeyDown,
 }) => {
   return (
     <StyledInput inputWidth={width}>
@@ -36,6 +38,7 @@ const TextInput: FC<Props> = ({
               additionalEffects(e);
             }
           }}
+          onKeyDown={onKeyDown}
         />
       </div>
     </StyledInput>

--- a/pages/testing.tsx
+++ b/pages/testing.tsx
@@ -31,19 +31,15 @@ const Testing = () => {
   const [longTokenAddress, setLongTokenAddress] = useState("");
   const [shortTokenAddress, setShortTokenAddress] = useState("");
 
-  const {
-    balance: longTokenBalance,
-    decimals: longTokenDecimals,
-    refetchBalance: refetchLongTokenBalance,
-  } = useERC20ContractValues(
-    longTokenAddress,
-    address,
-    web3Provider ? web3Provider.getSigner() : null
-  );
+  const { balance: longTokenBalance, refetchBalance: refetchLongTokenBalance } =
+    useERC20ContractValues(
+      longTokenAddress,
+      address,
+      web3Provider ? web3Provider.getSigner() : null
+    );
 
   const {
     balance: shortTokenBalance,
-    decimals: shortTokenDecimals,
     refetchBalance: refetchShortTokenBalance,
   } = useERC20ContractValues(
     shortTokenAddress,
@@ -104,9 +100,7 @@ const Testing = () => {
       setCollateralBalance={setCollateralBalance}
       collateralDecimals={collateralDecimals}
       longTokenBalance={longTokenBalance}
-      longTokenDecimals={longTokenDecimals}
       shortTokenBalance={shortTokenBalance}
-      shortTokenDecimals={shortTokenDecimals}
       refetchLongTokenBalance={refetchLongTokenBalance}
       refetchShortTokenBalance={refetchShortTokenBalance}
     />


### PR DESCRIPTION
**Motivation**
Be able to redeem functions from LSP range contract

**Summary**
1) Connected redeem form to contract.
2)  Added keydown function to prevent non-numeric characters, outside of a couple specific ones.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested