### PR TITLE
Integrate with api

### DIFF
--- a/components/EmpHero.tsx
+++ b/components/EmpHero.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import { Card as UnstyledCard } from "./Card";
+import { Value } from "./Value";
+
+import { formatMillions, formatWeiString, QUERIES } from "../utils";
+import type { Synth } from "../utils/umaApi";
+
+type Props = {
+  synth: Synth<{ type: "emp" }>;
+  change24h: number;
+};
+
+export const EmpHero: React.FC<Props> = ({ synth, change24h }) => {
+  return (
+    <CardWrapper>
+      <Card>
+        <CardContent>
+          <CardHeading>
+            Total Value Locked <span>(TVL)</span>
+          </CardHeading>
+          <Value
+            value={synth.tvl}
+            format={(v) => {
+              const formattedValue = formatWeiString(v);
+              return (
+                <>
+                  ${formatMillions(Math.floor(formattedValue))}{" "}
+                  <span style={{ fontWeight: 400 }}>
+                    {formattedValue >= 10 ** 9
+                      ? "B"
+                      : formattedValue >= 10 ** 6
+                      ? "M"
+                      : ""}
+                  </span>
+                </>
+              );
+            }}
+          />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <CardHeading>Token Price</CardHeading>
+          <Value
+            value={synth.tokenMarketPrice}
+            format={(v) => `$${formatWeiString(v).toFixed(2)}`}
+          ></Value>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <CardHeading>
+            Change <span>(24h)</span>
+          </CardHeading>
+          <Value
+            value={change24h}
+            format={(v) => <span style={{ color: "var(--green)" }}>{v} %</span>}
+          />
+        </CardContent>
+      </Card>
+    </CardWrapper>
+  );
+};
+
+const Card = styled(UnstyledCard)`
+  position: relative;
+`;
+const CardContent = styled.div`
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  & > h3 {
+    font-weight: 700;
+  }
+  & > div {
+    color: var(--primary);
+    font-size: clamp(1.375rem, 1.3vw + 1.1rem, 2.25rem);
+    font-weight: 700;
+  }
+`;
+
+const CardHeading = styled.h3`
+  font-weight: 600;
+  & > span {
+    font-weight: 300;
+  }
+`;
+const CardWrapper = styled.div`
+  color: var(--gray-700);
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  grid-template-rows: auto;
+  row-gap: 10px;
+  margin-top: 30px;
+  @media ${QUERIES.tabletAndUp} {
+    column-gap: 20px;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: fit-content 1fr;
+  }
+`;

--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -4,15 +4,17 @@ import { ethers } from "ethers";
 import { DateTime } from "luxon";
 
 import { QUERIES } from "../utils";
-import type { Emp } from "../utils/umaApi";
+import type { Synth } from "../utils/umaApi";
 import DuplicateIcon from "../public/icons/duplicate.svg";
 
-type Props = {
-  synth: Emp;
-};
+type Props =
+  | {
+      synth: Synth<{ type: "lsp" }>;
+    }
+  | { synth: Synth<{ type: "emp" }> };
 export const Information: React.FC<Props> = ({ synth }) => {
-  const handleCopyClick = () => {
-    window.navigator.clipboard.writeText(synth.tokenCurrency);
+  const handleCopyClick = (text: string) => {
+    window.navigator.clipboard.writeText(text);
   };
   return (
     <Wrapper>
@@ -20,19 +22,52 @@ export const Information: React.FC<Props> = ({ synth }) => {
       <Table>
         <Row>
           <div>Name:</div>
-          <div>{synth.tokenName}</div>
+          <div>
+            {synth.type == "emp" ? synth.tokenName : synth.longTokenName}
+          </div>
         </Row>
         <Row>
           <div>Symbol:</div>
-          <div>{synth.tokenSymbol}</div>
-        </Row>
-        <Row>
-          <div>Address:</div>
           <div>
-            {synth.tokenCurrency}{" "}
-            <StyledDuplicateIcon onClick={handleCopyClick} />
+            {synth.type == "emp"
+              ? synth.tokenSymbol
+              : `${synth.longTokenSymbol}-${synth.shortTokenSymbol}`}
           </div>
         </Row>
+
+        {synth.type === "emp" ? (
+          <Row>
+            <div>Address:</div>
+            <div>
+              {synth.tokenCurrency}{" "}
+              <StyledDuplicateIcon
+                onClick={() => handleCopyClick(synth.tokenCurrency)}
+              />
+            </div>
+          </Row>
+        ) : (
+          <>
+            <Row>
+              <div>Long Address:</div>
+              <div>
+                {synth.longToken}{" "}
+                <StyledDuplicateIcon
+                  onClick={() => handleCopyClick(synth.longToken)}
+                />
+              </div>
+            </Row>
+            <Row>
+              <div>Short Address:</div>
+              <div>
+                {synth.shortToken}{" "}
+                <StyledDuplicateIcon
+                  onClick={() => handleCopyClick(synth.shortToken)}
+                />
+              </div>
+            </Row>
+          </>
+        )}
+
         <Row>
           <div>Category:</div>
           <div>{synth.category}</div>
@@ -49,26 +84,30 @@ export const Information: React.FC<Props> = ({ synth }) => {
           <div>Price Identifier:</div>
           <div>{synth.priceIdentifier}</div>
         </Row>
-        <Row>
-          <div>Identifier Price:</div>
-          <div>{synth.identifierPrice}</div>
-        </Row>
-        <Row>
-          <div>Global Collateral Ratio:</div>
-          <div>{ethers.utils.formatEther(synth.gcr)}</div>
-        </Row>
-        <Row>
-          <div>Collateral Requirement:</div>
-          <div>{ethers.utils.formatEther(synth.collateralRequirement)}</div>
-        </Row>
-        <Row>
-          <div>Unique Sponsors:</div>
-          <div>{synth.sponsors.length}</div>
-        </Row>
-        <Row>
-          <div>Minimum Sponsor Tokens:</div>
-          <div>{ethers.utils.formatEther(synth.minSponsorTokens)}</div>
-        </Row>
+        {synth.type === "emp" && (
+          <>
+            <Row>
+              <div>Identifier Price:</div>
+              <div>{synth.identifierPrice}</div>
+            </Row>
+            <Row>
+              <div>Global Collateral Ratio:</div>
+              <div>{ethers.utils.formatEther(synth.gcr)}</div>
+            </Row>
+            <Row>
+              <div>Collateral Requirement:</div>
+              <div>{ethers.utils.formatEther(synth.collateralRequirement)}</div>
+            </Row>
+            <Row>
+              <div>Unique Sponsors:</div>
+              <div>{synth.sponsors.length}</div>
+            </Row>
+            <Row>
+              <div>Minimum Sponsor Tokens:</div>
+              <div>{ethers.utils.formatEther(synth.minSponsorTokens)}</div>
+            </Row>
+          </>
+        )}
       </Table>
     </Wrapper>
   );

--- a/components/LspHero.tsx
+++ b/components/LspHero.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import type { Synth } from "../utils/umaApi";
+
+type Props = {
+  synth: Synth<{ type: "lsp" }>;
+};
+export const LspHero: React.FC<Props> = ({ synth }) => {
+  return (
+    <Wrapper>
+      <div>Placeholders here</div>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div``;

--- a/components/LspHero.tsx
+++ b/components/LspHero.tsx
@@ -6,7 +6,7 @@ import type { Synth } from "../utils/umaApi";
 type Props = {
   synth: Synth<{ type: "lsp" }>;
 };
-export const LspHero: React.FC<Props> = ({ synth }) => {
+export const LspHero: React.FC<Props> = () => {
   return (
     <Wrapper>
       <div>Placeholders here</div>

--- a/components/SynthPlaceholderIcon.tsx
+++ b/components/SynthPlaceholderIcon.tsx
@@ -18,6 +18,8 @@ const placeholders: Record<
   Option: Option,
   "Synthetic Asset": SyntheticAsset,
   "Yield Dollar": YieldDollar,
+  "Range Token": SyntheticAsset,
+  "Success Token": SyntheticAsset,
 };
 
 export const SynthPlaceholderIcon: React.FC<Props> = ({
@@ -25,5 +27,8 @@ export const SynthPlaceholderIcon: React.FC<Props> = ({
   ...delegated
 }) => {
   const Component = placeholders[category];
+  if (!Component) {
+    return null;
+  }
   return <Component {...delegated} />;
 };

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 
 import Image from "next/image";
 import { useRouter } from "next/router";
+import { DateTime } from "luxon";
 
 import styled from "@emotion/styled";
 import { motion, AnimatePresence } from "framer-motion";
@@ -26,7 +27,7 @@ import {
 
 import { MaxWidthWrapper } from "./Wrapper";
 import { BaseButton } from "./Button";
-import { Synth } from "../utils/umaApi";
+import { Synth, formatLSPName } from "../utils/umaApi";
 
 const RankCircle = styled.div`
   border-radius: 9999px;
@@ -40,10 +41,11 @@ const RankCircle = styled.div`
     color: var(--gray-700);
   }
 `;
-
-const Name: React.FC<
-  Pick<Synth, "shortDescription" | "tokenName" | "category" | "logo">
-> = ({ logo, category, tokenName, shortDescription }) => {
+type NameProps = {
+  synth: Synth<any>;
+};
+const Name: React.FC<NameProps> = ({ synth }) => {
+  const { logo, category } = synth;
   // Contentful won't return an absolute URL so we have to complete it or next/image won't parse it
   const formattedUrl = logo?.fields.file.url
     ? formatContentfulUrl(logo.fields.file.url)
@@ -56,8 +58,13 @@ const Name: React.FC<
       </ImageWrapper>
 
       <div>
-        <NameHeading>{tokenName}</NameHeading>
-        <span>{shortDescription}</span>
+        <NameHeading>
+          {synth.type === "emp"
+            ? synth.tokenName
+            : formatLSPName(synth.longTokenName)}
+        </NameHeading>
+
+        <span>{synth.shortDescription}</span>
       </div>
     </NameWrapper>
   );
@@ -118,20 +125,13 @@ const columns = [
   {
     Header: "Name",
     // eslint-disable-next-line react/display-name
-    accessor: (row) => (
-      <Name
-        logo={row.logo}
-        tokenName={row.tokenName}
-        shortDescription={row.shortDescription}
-        category={row.category}
-      />
-    ),
+    accessor: (row) => <Name synth={row} />,
   },
   {
     Header: "Category",
     // set the Id here so we can reference it safely when filtering™
     id: "category",
-    accessor: (row: Synth) => capitalize(row.category),
+    accessor: (row) => capitalize(row.category),
     filter: "category",
   },
 
@@ -165,7 +165,7 @@ const columns = [
       </span>
     ),
   },
-] as Column<Synth>[];
+] as Column<Synth<any>>[];
 
 function activeSynthsFilter(
   rows: TRow[],
@@ -175,10 +175,14 @@ function activeSynthsFilter(
   if (!globalFilterValue) {
     return rows;
   }
-  return rows.filter((row) => !(row.original as Synth).expired);
+  return rows.filter(
+    (row) =>
+      (row.original as Synth<any>).expirationTimestamp >
+      DateTime.now().toSeconds()
+  );
 }
 type Props = {
-  data: Synth[];
+  data: Synth<any>[];
   hasFilters?: boolean;
 };
 export const Table: React.FC<Props> = ({ data, hasFilters = true }) => {

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -26,7 +26,7 @@ import {
 
 import { MaxWidthWrapper } from "./Wrapper";
 import { BaseButton } from "./Button";
-import { Emp } from "../utils/umaApi";
+import { Synth } from "../utils/umaApi";
 
 const RankCircle = styled.div`
   border-radius: 9999px;
@@ -42,7 +42,7 @@ const RankCircle = styled.div`
 `;
 
 const Name: React.FC<
-  Pick<Emp, "shortDescription" | "tokenName" | "category" | "logo">
+  Pick<Synth, "shortDescription" | "tokenName" | "category" | "logo">
 > = ({ logo, category, tokenName, shortDescription }) => {
   // Contentful won't return an absolute URL so we have to complete it or next/image won't parse it
   const formattedUrl = logo?.fields.file.url
@@ -131,7 +131,7 @@ const columns = [
     Header: "Category",
     // set the Id here so we can reference it safely when filtering™
     id: "category",
-    accessor: (row: Emp) => capitalize(row.category),
+    accessor: (row: Synth) => capitalize(row.category),
     filter: "category",
   },
 
@@ -165,7 +165,7 @@ const columns = [
       </span>
     ),
   },
-] as Column<Emp>[];
+] as Column<Synth>[];
 
 function activeSynthsFilter(
   rows: TRow[],
@@ -175,10 +175,10 @@ function activeSynthsFilter(
   if (!globalFilterValue) {
     return rows;
   }
-  return rows.filter((row) => !(row.original as Emp).expired);
+  return rows.filter((row) => !(row.original as Synth).expired);
 }
 type Props = {
-  data: Emp[];
+  data: Synth[];
   hasFilters?: boolean;
 };
 export const Table: React.FC<Props> = ({ data, hasFilters = true }) => {

--- a/components/Value.tsx
+++ b/components/Value.tsx
@@ -2,14 +2,14 @@ import React from "react";
 
 type Props =
   | {
-      value: number;
+      value: number | string;
       defaultValue?: string;
-      format?: (v: number) => React.ReactNode;
+      format?: (v: number | string) => React.ReactNode;
     }
   | {
-      value?: number;
+      value?: number | string;
       defaultValue: string;
-      format?: (v: number) => React.ReactNode;
+      format?: (v: number | string) => React.ReactNode;
     };
 
 export const Value: React.FC<Props> = ({

--- a/components/index.ts
+++ b/components/index.ts
@@ -14,3 +14,5 @@ export * from "./LineChart";
 export * from "./About";
 export * from "./Information";
 export * from "./Placeholder";
+export * from "./EmpHero";
+export * from "./LspHero";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,18 +21,14 @@ import {
   ContentfulSynth,
 } from "../utils";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { client, Emp, fetchCompleteSynth } from "../utils/umaApi";
+import { client, fetchCompleteSynth } from "../utils/umaApi";
 
 export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
   const cmsSynths = await contentfulClient.getAllSynths();
 
-  await queryClient.prefetchQuery(
-    "all synths",
-    async () =>
-      (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(
-        errorFilter
-      ) as Emp[]
+  await queryClient.prefetchQuery("all synths", async () =>
+    (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(errorFilter)
   );
   await queryClient.prefetchQuery(
     "total tvl",
@@ -58,12 +54,8 @@ export const getStaticProps: GetStaticProps = async () => {
 const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   cmsSynths,
 }) => {
-  const { data: allSynths } = useQuery(
-    "all synths",
-    async () =>
-      (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(
-        errorFilter
-      ) as Emp[]
+  const { data: allSynths } = useQuery("all synths", async () =>
+    (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(errorFilter)
   );
   const { data: totalTvl } = useQuery(
     "total tvl",
@@ -94,11 +86,11 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
                 Total Value Locked <span>(TVL)</span>
               </CardHeading>
               <Value
-                value={formatWeiString(totalTvl!)}
+                value={totalTvl ?? 0}
                 format={(v) => {
                   return (
                     <>
-                      ${formatMillions(Math.floor(v))}{" "}
+                      ${formatMillions(Math.floor(formatWeiString(v)))}{" "}
                       <span style={{ fontWeight: 400 }}>
                         {v >= 10 ** 9 ? "B" : v >= 10 ** 6 ? "M" : ""}
                       </span>
@@ -114,11 +106,11 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
                 Total Value Minted <span>(TVM)</span>
               </CardHeading>
               <Value
-                value={formatWeiString(totalTvm ?? 0)}
+                value={totalTvm ?? 0}
                 format={(v) => {
                   return (
                     <>
-                      ${formatMillions(Math.floor(v))}{" "}
+                      ${formatMillions(Math.floor(formatWeiString(v)))}{" "}
                       <span style={{ fontWeight: 400 }}>
                         {v >= 10 ** 9 ? "B" : v >= 10 ** 6 ? "M" : ""}
                       </span>
@@ -135,7 +127,7 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
               </CardHeading>
               <Value
                 value={3.2}
-                format={(v: number) => (
+                format={(v) => (
                   <span style={{ color: "var(--green)" }}>{v} %</span>
                 )}
               />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ import {
   ContentfulSynth,
 } from "../utils";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { client, fetchCompleteSynth } from "../utils/umaApi";
+import { client, fetchCompleteSynth, Synth } from "../utils/umaApi";
 
 export const getStaticProps: GetStaticProps = async () => {
   const queryClient = new QueryClient();
@@ -54,8 +54,12 @@ export const getStaticProps: GetStaticProps = async () => {
 const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   cmsSynths,
 }) => {
-  const { data: allSynths } = useQuery("all synths", async () =>
-    (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(errorFilter)
+  const { data: allSynths } = useQuery(
+    "all synths",
+    async () =>
+      (await Promise.all(cmsSynths.map(fetchCompleteSynth))).filter(
+        errorFilter
+      ) as Synth<any>[]
   );
   const { data: totalTvl } = useQuery(
     "total tvl",
@@ -136,7 +140,7 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         </CardWrapper>
       </Hero>
 
-      <Table data={allSynths!} />
+      <Table data={allSynths ?? []} />
     </Layout>
   );
 };

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -32,6 +32,8 @@ export const CATEGORIES = [
   "KPI Option",
   "Synthetic Asset",
   "Option",
+  "Range Token",
+  "Success Token",
 ] as const;
 export type Category = typeof CATEGORIES[number];
 
@@ -40,6 +42,8 @@ export const CATEGORIES_PLACEHOLDERS: Record<Category, string> = {
   "KPI Option": "/placeholders/kpi-option.svg",
   "Synthetic Asset": "/placeholders/synthetic-asset.svg",
   Option: "/placeholders/option.svg",
+  "Range Token": "/placeholders/synthetic-asset.svg",
+  "Success Token": "/placeholders/synthetic-asset.svg",
 };
 
 export const KNOWN_LSP_ADDRESS = "0x372802d8A2D69bB43872a1AABe2bd403a0FafA1F";

--- a/utils/contentful.ts
+++ b/utils/contentful.ts
@@ -42,6 +42,7 @@ export type ContentfulSynth = {
   address: string;
   description: string;
   logo?: Entry<ContentfulLogo>;
+  mintmanage: string;
 };
 
 export function formatContentfulUrl(url: string): string {

--- a/utils/umaApi.ts
+++ b/utils/umaApi.ts
@@ -11,7 +11,8 @@ const baseOptions = {
   method: "POST",
 };
 
-const baseUrl = process.env.UMA_API_URL || "https://prod.api.umaproject.org";
+const baseUrl =
+  process.env.NEXT_PUBLIC_UMA_API_URL || "https://prod.api.umaproject.org";
 
 function constructRequest(...params: unknown[]) {
   try {
@@ -37,8 +38,8 @@ export async function request<T>(
   }
   return response.json();
 }
-
-export type EmpState = {
+// Basic types
+interface EmpState {
   id: string;
   address: string;
   priceIdentifier: string;
@@ -70,39 +71,90 @@ export type EmpState = {
   gcr: string;
   identifierPrice: string;
   tokenMarketPrice: string;
-};
-export type EmpStats = {
+  type: "emp";
+}
+interface LspState {
+  id: string;
+  address: string;
+  updated: number;
+  collateralPerPair: string;
+  priceIdentifier: string;
+  collateralToken: string;
+  longToken: string;
+  shortToken: string;
+  finder: string;
+  financialProductLibrary: string;
+  customAncillaryData: string;
+  prepaidProposerReward: number;
+  expirationTimestamp: number;
+  expiryPrice: string;
+  expiryPercentLong: string;
+  contractState: number;
+  totalPositionCollateral: string;
+  sponsors: string[];
+  longTokenDecimals: number;
+  shortTokenDecimals: number;
+  collateralDecimals: number;
+  longTokenName: string;
+  shortTokenName: string;
+  collateralName: string;
+  longTokenSymbol: string;
+  shortTokenSymbol: string;
+  collateralSymbol: string;
+  type: "lsp";
+}
+export type ContractType = "emp" | "lsp";
+export type SynthState<T extends { type: ContractType }> = T extends {
+  type: "emp";
+}
+  ? EmpState
+  : LspState;
+
+export type SynthStats = {
   id: string;
   address: string;
   tvl: string;
   tvm: string;
 };
+export type Synth<T extends { type: ContractType }> = ContentfulSynth &
+  SynthStats &
+  SynthState<T> & { tvl24hChange: number };
+
 export type TimeSeries = {
   id: string;
   address: string;
   value: string;
   timestamp: number;
 }[];
-type GetEmpsAddresses = () => Promise<string[]>;
-type GetEmpState = (address: string) => Promise<EmpState>;
-type GetEmpsState = (address: string) => Promise<EmpState[]>;
-type GetEmpStats = (address: string) => Promise<EmpStats>;
+
+// Function types
+type GetAddresses = () => Promise<string[]>;
+type GetState = <T extends { type: ContractType }>(
+  address: string
+) => Promise<SynthState<T>>;
+
+// type GetSynthsState = (address: string) => Promise<SynthState[]>;
+type GetSynthStats = (address: string) => Promise<SynthStats>;
 type GetStat = (addresses?: string | string[]) => Promise<string>;
 type GetStatBetween = (
   addresses: string | string[],
   startTimestamp?: number
-) => Promise<EmpStats[]>;
+) => Promise<SynthStats[]>;
 
 type GetPriceSlice = (address: string) => Promise<string[]>;
 
-const getEmpsAddresses: GetEmpsAddresses = () => request("listEmpAddresses");
-const getEmpState: GetEmpState = (address) => request("getEmpState", address);
-const getEmpsState: GetEmpsState = () =>
-  getEmpsAddresses().then((addresses) =>
-    Promise.all(addresses.map(getEmpState))
-  );
+const getAddresses: GetAddresses = async () => {
+  const empAddresses: string[] = await request("listEmpAddresses");
+  const lspAddresses: string[] = await request("listAddresses");
+  return [...empAddresses, ...lspAddresses];
+};
 
-const getEmpStats: GetEmpStats = async (address) => {
+const getState: GetState = async (address) => {
+  const state: any = await request("global/getState", address);
+  return state;
+};
+
+const getSynthStats: GetSynthStats = async (address) => {
   return {
     id: address,
     address,
@@ -130,26 +182,21 @@ const getYesterdayPrice: GetPriceSlice = (address: string) =>
   );
 export const client = {
   request,
-  getEmpsAddresses,
-  getEmpState,
-  getEmpsState,
-  getEmpStats,
+  getAddresses,
+  getState,
+  getSynthStats,
   getLatestTvl,
   getLatestTvm,
   getTvl,
   getYesterdayPrice,
 };
 
-export type Emp = ContentfulSynth &
-  EmpStats &
-  EmpState & { tvl24hChange: number };
-
-export async function fetchCompleteSynth(
+export async function fetchCompleteSynth<T extends { type: ContractType }>(
   synth: ContentfulSynth
-): Promise<Emp | Error> {
+): Promise<Synth<T> | Error> {
   try {
-    const stats = await client.getEmpStats(synth.address);
-    const state = await client.getEmpState(synth.address);
+    const stats = await client.getSynthStats(synth.address);
+    const state = await client.getState<T>(synth.address);
     const lastTvl = await client.getLatestTvl(synth.address);
     const [{ value: ydayTvl }] = await client.request(
       "tvlHistorySlice",
@@ -172,4 +219,8 @@ export async function fetchCompleteSynth(
   } catch (err) {
     return new SynthFetchingError(err.message, synth);
   }
+}
+
+export function formatLSPName(longTokenName: string): string {
+  return longTokenName.substring(-2);
 }


### PR DESCRIPTION
**Motivation**
This PR integrates the new API calls with umaverse UI. It does not however, merge the testing page into the address page 


**Details**
The API client has been refactored to accomodate for the new API, the `[address]` page now can distinguish between LSPs and EMPs and will render different views based on that.
**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested