### PR TITLE
fix(umaverse): remove curated address for tvm

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,6 @@ import {
   QUERIES,
   errorFilter,
   formatWeiString,
-  ContentfulSynth,
 } from "../utils";
 
 import {
@@ -88,10 +87,7 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   );
   const { data: totalTvm } = useQuery(
     "total tvm",
-    async () =>
-      await client.getLatestTvm(
-        cmsSynths.map((synth: ContentfulSynth) => synth.address)
-      )
+    async () => await client.getLatestTvm()
   );
   const { data: totalTvlChange } = useQuery(
     "total tvl change",


### PR DESCRIPTION
**Motivation**
This PR fixes a minor bug making the TVM call error and thus not providing fresh values for global tvm

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested