### PR TITLE
fix(token-information): minor formatting improvements for price and min tokens

### DIFF
--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -96,7 +96,7 @@ export const Information: React.FC<Props> = ({ synth }) => {
           <>
             <Row>
               <div>Identifier Price:</div>
-              <div>{synth.identifierPrice}</div>
+              <div>{ethers.utils.formatEther(synth.identifierPrice)}</div>
             </Row>
             <Row>
               <div>Global Collateral Ratio:</div>
@@ -112,7 +112,12 @@ export const Information: React.FC<Props> = ({ synth }) => {
             </Row>
             <Row>
               <div>Minimum Sponsor Tokens:</div>
-              <div>{ethers.utils.formatEther(synth.minSponsorTokens)}</div>
+              <div>
+                {ethers.utils.formatUnits(
+                  synth.minSponsorTokens,
+                  synth.tokenDecimals
+                )}
+              </div>
             </Row>
           </>
         )}

--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -94,10 +94,12 @@ export const Information: React.FC<Props> = ({ synth }) => {
         </Row>
         {synth.type === "emp" && (
           <>
-            <Row>
-              <div>Identifier Price:</div>
-              <div>{ethers.utils.formatEther(synth.identifierPrice)}</div>
-            </Row>
+            {synth.identifierPrice && (
+              <Row>
+                <div>Identifier Price:</div>
+                <div>{ethers.utils.formatEther(synth.identifierPrice)}</div>
+              </Row>
+            )}
             <Row>
               <div>Global Collateral Ratio:</div>
               <div>{ethers.utils.formatEther(synth.gcr)}</div>


### PR DESCRIPTION
Very minor formatting improvements.

The raw price value returned by the price id should be divided by 1e18.

The min tokens needs to be divided by the 1e[token_decimals], not necessarily 1e18.

Note: it may also make sense to have a standard way of formatting decimals because a lot of them go out to many more sig-figs than necessary because of the high-precision in solidity. We may want to have a standard way to deal with this, but that seemed more involved and opinionated, so I wanted to leave it to those with more expertise.

Before:

<img width="742" alt="Screen Shot 2021-08-12 at 2 07 13 PM" src="https://user-images.githubusercontent.com/11791551/129246809-b7c756ae-22ce-4c7d-bf1d-8ecd3c2137b4.png">

After:

<img width="731" alt="Screen Shot 2021-08-12 at 2 04 36 PM" src="https://user-images.githubusercontent.com/11791551/129246856-06077698-bace-4dde-b87e-ff9d3923d1a2.png">

