### PR TITLE
feat: Split approve and mint, show in UI

### DIFF
--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -72,13 +72,6 @@ const MintForm: FC<Props> = ({
   const [userNeedsToApprove, setUserNeedsToApprove] = useState(false);
   const { signer } = useConnection();
 
-  useEffect(() => {
-    if (signer) {
-      setShowWallet(false);
-      checkIfUserHasToApprove();
-    }
-  }, [signer, setShowWallet]);
-
   const checkIfUserHasToApprove = useCallback(async () => {
     if (collateralERC20Contract) {
       const allowance = await collateralERC20Contract.allowance(
@@ -92,6 +85,13 @@ const MintForm: FC<Props> = ({
       }
     }
   }, [collateralERC20Contract, setUserNeedsToApprove]);
+
+  useEffect(() => {
+    if (signer) {
+      setShowWallet(false);
+      checkIfUserHasToApprove();
+    }
+  }, [signer, setShowWallet, checkIfUserHasToApprove]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
**Motivation**
 
UI should split approve and mint transactions.


**Details**

<img width="655" alt="Screen Shot 2021-08-13 at 1 29 47 PM" src="https://user-images.githubusercontent.com/12792146/129415221-70551aec-62c7-4fb1-9cdf-9673a2ac01f3.png">


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested