### PR TITLE
feat(umaverse): add persistence to table filters

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -188,6 +188,9 @@ type Props = {
 };
 
 const sortedCategories = CATEGORIES.slice().sort();
+const SET_FILTER_ACTION = "setFilter";
+const SET_GLOBAL_FILTER_ACTION = "setGlobalFilter";
+
 export const Table: React.FC<Props> = ({ data, hasFilters = true }) => {
   const tableData = useMemo(
     () => data.sort((a, b) => formatWeiString(b.tvl) - formatWeiString(a.tvl)),
@@ -235,14 +238,14 @@ export const Table: React.FC<Props> = ({ data, hasFilters = true }) => {
       autoResetFilters: false,
       autoResetGlobalFilter: false,
       stateReducer: (newState, action) => {
-        if (action.type === "setFilter") {
+        if (action.type === SET_FILTER_ACTION) {
           setCachedFilters((prevFilters) => ({
             ...prevFilters,
             // @ts-expect-error React table options change based on the plugin used, but its not typed correctly so TS doesn't pick it up.
             filters: newState.filters,
           }));
         }
-        if (action.type === "setGlobalFilter") {
+        if (action.type === SET_GLOBAL_FILTER_ACTION) {
           setCachedFilters((prevFilters) => ({
             ...prevFilters,
             // @ts-expect-error React table options change based on the plugin used, but its not typed correctly so TS doesn't pick it up.

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useConnection";
 export * from "./useOnboard";
+export * from "./useCachedState";

--- a/hooks/useCachedState.tsx
+++ b/hooks/useCachedState.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
+
+const stateMap = new Map();
+
+/* This hook is used to cache state between mount/umount of the same component 
+  It is meant to be used for things that are specific to one component only but have to be persisted between unmounts (table filters after a page transition for example). 
+*/
+export function useCachedState<T = unknown>(
+  key: string
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(stateMap.get(key));
+
+  useEffect(() => {
+    stateMap.set(key, state);
+  }, [key, state]);
+  return [state, setState];
+}


### PR DESCRIPTION
**Motivation**
This PR adds persistence for Table filters as requested by: https://app.clubhouse.io/uma-project/story/1961/when-a-user-filters-and-selects-a-token-and-then-clicks-back-the-filter-they-previously-selected-should-still-be-displayed


**Details**
I've added a hook called `useCachedState` which takes care of persisting state between mount/unmount of components with the same "key" , in this specific use case, I've used it with key "table" 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested