### PR TITLE
feat(umaverse): change grid structure

### DIFF
--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -9,16 +9,17 @@ import DuplicateIcon from "../public/icons/duplicate.svg";
 
 type Props =
   | {
+      className?: string;
       synth: Synth<{ type: "lsp" }>;
     }
-  | { synth: Synth<{ type: "emp" }> };
-export const Information: React.FC<Props> = ({ synth }) => {
+  | { className?: string; synth: Synth<{ type: "emp" }> };
+export const Information: React.FC<Props> = ({ synth, className }) => {
   const handleCopyClick = (text: string) => {
     window.navigator.clipboard.writeText(text);
   };
 
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       <Heading>Token Information</Heading>
       <Table>
         <Row>

--- a/pages/[address].tsx
+++ b/pages/[address].tsx
@@ -319,21 +319,51 @@ const SynthPage: React.FC<Props> = ({ data, relatedSynths }) => {
         )}
       </Hero>
       <MainWrapper>
-        <About description={data.description} />
-
+        <div>
+          <About description={data.description} />
+          <Information synth={freshData as Synth<{ type: ContractType }>} />
+        </div>
         <AsideWrapper>
           {data.type === "emp" ? (
             <>
-              <SecondaryHeading>Total Value Locked (TVL)</SecondaryHeading>
-              <ChartWrapper>
-                <ResponsiveLineChart
-                  // @ts-expect-error bla
-                  data={tvlHistory ?? []}
-                  isLoading={isLoadingTvl}
-                />
-              </ChartWrapper>
+              <div>
+                <SecondaryHeading>Total Value Locked (TVL)</SecondaryHeading>
+                <ChartWrapper>
+                  <ResponsiveLineChart
+                    // @ts-expect-error bla
+                    data={tvlHistory ?? []}
+                    isLoading={isLoadingTvl}
+                  />
+                </ChartWrapper>
+              </div>
+              <div>
+                <SecondaryHeading>Manage Position</SecondaryHeading>
+                <ul>
+                  <Link href={data.mintmanage}>
+                    Mint / Manage <ExternalLink />
+                  </Link>
+                  <Link
+                    href={`https://matcha.xyz/markets/1/${data.tokenCurrency.toLowerCase()}`}
+                  >
+                    Trade
+                    <ExternalLink />
+                  </Link>
+                  <Link href={`https://etherscan.io/address/${data.address}`}>
+                    Etherscan <span>[Contract]</span> <ExternalLink />
+                  </Link>
+                  <Link
+                    href={`https://etherscan.io/address/${data.tokenCurrency}`}
+                  >
+                    Etherscan <span>[Token] {data.type}</span>
+                    <ExternalLink />
+                  </Link>
+                  <Link href="https://docs.umaproject.org">
+                    UMA Docs <RightArrow />
+                  </Link>
+                </ul>
+              </div>
             </>
-          ) : data.type === "lsp" ? (
+          ) : (
             <LSP
               data={data}
               contractAddress={data.address}
@@ -345,38 +375,7 @@ const SynthPage: React.FC<Props> = ({ data, relatedSynths }) => {
               collateralBalance={collateralBalance}
               setCollateralBalance={setCollateralBalance}
             />
-          ) : null}
-        </AsideWrapper>
-        <Information synth={freshData as Synth<{ type: ContractType }>} />
-        <AsideWrapper>
-          {data.type === "emp" ? (
-            <>
-              <SecondaryHeading>Manage Position</SecondaryHeading>
-              <ul>
-                <Link href={data.mintmanage}>
-                  Mint / Manage <ExternalLink />
-                </Link>
-                <Link
-                  href={`https://matcha.xyz/markets/1/${data.tokenCurrency.toLowerCase()}`}
-                >
-                  Trade
-                  <ExternalLink />
-                </Link>
-                <Link href={`https://etherscan.io/address/${data.address}`}>
-                  Etherscan <span>[Contract]</span> <ExternalLink />
-                </Link>
-                <Link
-                  href={`https://etherscan.io/address/${data.tokenCurrency}`}
-                >
-                  Etherscan <span>[Token] {data.type}</span>
-                  <ExternalLink />
-                </Link>
-                <Link href="https://docs.umaproject.org">
-                  UMA Docs <RightArrow />
-                </Link>
-              </ul>
-            </>
-          ) : null}
+          )}
         </AsideWrapper>
       </MainWrapper>
       <GettingStarted />
@@ -472,9 +471,8 @@ const SecondaryHeading = styled.h3`
 `;
 
 const Information = styled(UnstyledInformation)`
-  order: 1;
   @media ${QUERIES.laptopAndUp} {
-    order: revert;
+    padding-bottom: 60px;
   }
 `;
 
@@ -487,7 +485,10 @@ const AsideWrapper = styled.aside`
 
   @media ${QUERIES.laptopAndUp} {
     margin: revert;
-  } ;
+  }
+  & > div:nth-of-type(2) {
+    padding-top: 20px;
+  }
 `;
 
 const ChartWrapper = styled.div`


### PR DESCRIPTION
**Motivation**
This PR collapses the grid into 2 columns instead of 4

Before:
<img width="1142" alt="CleanShot 2021-08-24 at 11 40 41@2x" src="https://user-images.githubusercontent.com/29527327/130594945-b6aaf977-7cd4-49b4-a6ad-f1bddacb26cc.png">

After:
<img width="1282" alt="CleanShot 2021-08-24 at 11 39 39@2x" src="https://user-images.githubusercontent.com/29527327/130594963-1faed222-f2fe-4bd0-82d2-63906e98d3be.png">

https://app.clubhouse.io/uma-project/story/1929/rework-the-grid-for-the-lsp-page


**Details**
To make this change without introducing a lot of complexity or changing the markup dynamically, I've changed the order of components of the grid on mobile. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested