### PR TITLE
fixed null percent.

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -162,7 +162,9 @@ const columns = [
           textAlign: "right",
         }}
       >
-        {Number.isNaN(row.tvl24hChange) || row.tvl24hChange === null
+        {Number.isNaN(row.tvl24hChange) ||
+        row.tvl24hChange === null ||
+        row.tvl24hChange === undefined
           ? "-"
           : `${row.tvl24hChange}%`}
       </span>

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -162,7 +162,9 @@ const columns = [
           textAlign: "right",
         }}
       >
-        {Number.isNaN(row.tvl24hChange) ? "-" : `${row.tvl24hChange}%`}
+        {Number.isNaN(row.tvl24hChange) || row.tvl24hChange === null
+          ? "-"
+          : `${row.tvl24hChange}%`}
       </span>
     ),
   },


### PR DESCRIPTION
TVL percent can sometimes be null. Show a "-" if it is.

https://app.shortcut.com/uma-project/story/2413/fix-minor-glitch-for-contracts-with-no-funding-for-a-couple-of-seconds-umaverse-shows-null-in-the-24h-change-field-afterwards

Signed-off-by: Tulun <jaykiraly@gmail.com>