### PR TITLE
fix: remove state guard to allow settle to be tested even if the contractState isn't expired

### DIFF
--- a/components/lsp/LSP.tsx
+++ b/components/lsp/LSP.tsx
@@ -51,11 +51,7 @@ const LSP: FC<Props> = ({
 
   // Check if contract is settable.
   useEffect(() => {
-    if (
-      signer &&
-      data.contractState === ContractState.ExpiredPriceRequested &&
-      lspContract
-    ) {
+    if (signer && lspContract) {
       lspContract.callStatic
         .settle(0, 0)
         .then(


### PR DESCRIPTION
Note; this change wouldn't make sense under normal circumstances, but the expected contractState data coming from the API seems to be undefined in at least some cases, so this routes around that issue for the settlement use case.