### PR TITLE
fix: fix approvals to check against amount input

### DIFF
--- a/components/lsp/LSP.tsx
+++ b/components/lsp/LSP.tsx
@@ -94,15 +94,19 @@ const LSP: FC<Props> = ({
     if (signer && data.address && account && collateralERC20Contract) {
       const lspCon = createLSPContractInstance(signer, data.address);
 
-      lspCon.getCurrentTime().then((ts: ethers.BigNumber) => {
-        setCurrentTime(ts.toString());
-      });
+      lspCon
+        .getCurrentTime()
+        .then((ts: ethers.BigNumber) => {
+          setCurrentTime(ts.toString());
+        })
+        .catch(console.error);
 
       collateralERC20Contract
         .balanceOf(account)
         .then((balance: ethers.BigNumber) => {
           setCollateralBalance(balance);
-        });
+        })
+        .catch(console.error);
 
       setLSPContract(lspCon);
     }

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -80,7 +80,7 @@ const MintForm: FC<Props> = ({
     collateralERC20Contract
       .allowance(address, contractAddress)
       .then(setKnownAllowance)
-      .catch((err: Error) => console.log("error getting allowance", err));
+      .catch((err: Error) => console.error("error getting allowance", err));
   }, [address, contractAddress, collateralERC20Contract, setKnownAllowance]);
 
   useEffect(() => {
@@ -219,7 +219,7 @@ const MintForm: FC<Props> = ({
           <ButtonWrapper>
             <MintButton
               id="mintButton"
-              showDisabled={!signer || showMintError || !amount ? true : false}
+              showDisabled={!signer || !!showMintError || Number(amount) <= 0}
               onClick={() => {
                 if (showMintError) return false;
                 if (signer) {

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -76,9 +76,7 @@ const MintForm: FC<Props> = ({
   );
 
   const getKnownAllowance = useCallback(() => {
-    if (!collateralERC20Contract) return;
-    if (!address) return;
-    if (!contractAddress) return;
+    if (!collateralERC20Contract || !address || !contractAddress) return;
     collateralERC20Contract
       .allowance(address, contractAddress)
       .then(setKnownAllowance)

--- a/hooks/useERC20ContractValues.ts
+++ b/hooks/useERC20ContractValues.ts
@@ -14,21 +14,30 @@ export default function useERC20ContractValues(
 
   const refetchBalance = useCallback(() => {
     if (contract && userAddress) {
-      contract.balanceOf(userAddress).then((bal: ethers.BigNumber) => {
-        setBalance(bal);
-      });
+      contract
+        .balanceOf(userAddress)
+        .then((bal: ethers.BigNumber) => {
+          setBalance(bal);
+        })
+        .catch(console.error);
     }
   }, [contract, userAddress]);
   useEffect(() => {
     if (contractAddress && signer && userAddress) {
       const erc20 = createERC20ContractInstance(signer, contractAddress);
-      erc20.decimals().then((decimals: ethers.BigNumber) => {
-        setDecimals(decimals.toString());
-      });
+      erc20
+        .decimals()
+        .then((decimals: ethers.BigNumber) => {
+          setDecimals(decimals.toString());
+        })
+        .catch(console.error);
 
-      erc20.balanceOf(userAddress).then((bal: ethers.BigNumber) => {
-        setBalance(bal);
-      });
+      erc20
+        .balanceOf(userAddress)
+        .then((bal: ethers.BigNumber) => {
+          setBalance(bal);
+        })
+        .catch(console.error);
       setContract(erc20);
     } else {
       setBalance(toBN("0"));

--- a/pages/[address].tsx
+++ b/pages/[address].tsx
@@ -270,9 +270,12 @@ const SynthPage: React.FC<Props> = ({ data, relatedSynths }) => {
       refetchShortTokenBalance();
       const erc20 = createERC20ContractInstance(signer, data.collateralToken);
       setCollateralERC20Contract(erc20);
-      erc20.balanceOf(account).then((balance: ethers.BigNumber) => {
-        setCollateralBalance(balance);
-      });
+      erc20
+        .balanceOf(account)
+        .then((balance: ethers.BigNumber) => {
+          setCollateralBalance(balance);
+        })
+        .catch(console.error);
     }
     if (!isConnected) {
       setCollateralBalance(toBN("0"));


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Motivation:
https://app.shortcut.com/uma-project/story/3539/unable-to-approve-certain-amounts-on-umaverse
User has limited approval, but app does not recognize it when minting

Fix:
We were comparing approvals against the users wallet balance rather than the amount set in the input field. This changes it so approvals are checked vs user input.

Tests:
Tested on mainnet manually