### PR TITLE
fix: determine on chain contract state

### DIFF
--- a/components/lsp/LSPForm.tsx
+++ b/components/lsp/LSPForm.tsx
@@ -67,6 +67,7 @@ const LSPForm: FC<Props> = ({
           .then((tx: any) => tx.wait(1))
           .then(() => {
             setContractState(ContractState.ExpiredPriceRequested);
+            setSettleButtonDisabled(true);
           });
       } catch (err) {
         console.log("err in expire call", err);

--- a/utils/umaApi.ts
+++ b/utils/umaApi.ts
@@ -73,7 +73,7 @@ interface EmpState {
   tokenMarketPrice: string;
   type: "emp";
 }
-interface LspState {
+export interface LspState {
   id: string;
   address: string;
   updated: number;
@@ -89,7 +89,6 @@ interface LspState {
   expirationTimestamp: number;
   expiryPrice: string;
   expiryPercentLong: string;
-  contractState: number;
   totalPositionCollateral: string;
   sponsors: string[];
   longTokenDecimals: number;


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Motivation
https://app.shortcut.com/uma-project/story/3744/eliminate-use-of-contract-state-variable-in-umaverse

Summary
Adds an additional check to see if we can expire then settle the contract. This lets us know what state the contract is in. No longer need to rely on api or previous abis for this particular variable.

Screens
![approve](https://user-images.githubusercontent.com/4429761/147254856-4ccd1aa4-1cc1-4cf6-aae7-b081afa11ce2.PNG)
![mint](https://user-images.githubusercontent.com/4429761/147254862-037af368-496c-4561-a117-38e60ea8627b.PNG)
![expire](https://user-images.githubusercontent.com/4429761/147254891-2bcaff7c-8be9-421e-94ac-8f04e53a7c8a.PNG)
![presettle](https://user-images.githubusercontent.com/4429761/147254898-9940e2ee-178d-43e2-b49b-b3e6a4a8df09.PNG)
![settle](https://user-images.githubusercontent.com/4429761/147254902-3ded71ea-aef8-4c23-b41a-fb792ad7c56f.PNG)
![settled](https://user-images.githubusercontent.com/4429761/147254904-ff7654ea-f350-4321-a943-c419534d99d4.PNG)

Testing
Tested using the hardhat testing scripts