### PR TITLE
feat(umaverse): refactor api client to use chain id

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ import {
 import {
   contentfulClient,
   formatMillions,
+  getGlobalTvm,
   QUERIES,
   errorFilter,
   formatWeiString,
@@ -23,12 +24,7 @@ import {
   SynthFetchingError,
 } from "../utils";
 
-import {
-  client,
-  ContractType,
-  fetchCompleteSynth,
-  Synth,
-} from "../utils/umaApi";
+import { constructClient, ContractType, Synth } from "../utils/umaApi";
 
 import {
   getDefillamaTvl,
@@ -64,7 +60,7 @@ function fetchCompleteSynthByApi(cmsSynth: ContentfulSynth) {
   if (cmsSynth.defiLlamaApi) {
     return attachDefillamaStats(cmsSynth);
   } else {
-    return fetchCompleteSynth(cmsSynth);
+    return constructClient(cmsSynth.chainId).fetchCompleteSynth(cmsSynth);
   }
 }
 
@@ -85,7 +81,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   await queryClient.prefetchQuery(
     "total tvm",
-    async () => await client.getLatestTvm()
+    async () => await getGlobalTvm()
   );
 
   await queryClient.prefetchQuery(
@@ -118,7 +114,7 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   );
   const { data: totalTvm } = useQuery(
     "total tvm",
-    async () => await client.getLatestTvm()
+    async () => await getGlobalTvm()
   );
   const { data: totalTvlChange } = useQuery(
     "total tvl change",

--- a/utils/chainId.ts
+++ b/utils/chainId.ts
@@ -1,5 +1,5 @@
 export type ValidChainId = 1 | 42 | 1337;
-export type ChainId = 1 | 42 | 1337 | 3 | 4;
+export type ChainId = 1 | 42 | 1337 | 3 | 4 | 137;
 
 export function isValidChainId(chainId: number): chainId is ValidChainId {
   return SUPPORTED_CHAIN_IDS.includes(chainId);

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./truncateAddress";
 export * from "./constants";
 export * from "./contentful";
 export * from "./errors";
+export * from "./umaApi";

--- a/utils/umaApi.ts
+++ b/utils/umaApi.ts
@@ -2,6 +2,17 @@ import type { ContentfulSynth } from "./contentful";
 import { nDaysAgo } from "./time";
 import { formatWeiString } from "./format";
 import { SynthFetchingError } from "./errors";
+import { ChainId } from "./chainId";
+import memoize from "lodash/memoize";
+import { BigNumber } from "ethers";
+
+const time90DaysAgo = nDaysAgo(90);
+const oneDayAgo = nDaysAgo(1);
+
+// longTokenName can return undefined if value wasn't found in API so we need to do a null check.
+export function formatLSPName(longTokenName: string): string {
+  return longTokenName?.substring(-2);
+}
 
 const baseOptions = {
   headers: {
@@ -11,32 +22,142 @@ const baseOptions = {
   method: "POST",
 };
 
-const baseUrl =
-  process.env.NEXT_PUBLIC_UMA_API_URL || "https://prod.api.umaproject.org";
+const API_URLS: Record<ChainId, string> = {
+  1: "https://prod.api.umaproject.org",
+  42: "https://dev.api.umaproject.org",
+  3: "https://dev.api.umaproject.org",
+  4: "https://dev.api.umaproject.org",
+  1337: "https://dev.api.umaproject.org",
+  137: "https://prod.api.umaproject.org",
+};
 
-function constructRequest(...params: unknown[]) {
-  try {
-    return { ...baseOptions, body: JSON.stringify([...params]) };
-  } catch (e) {
-    throw new Error(`Could not stringify ${params}`);
+function _constructClient(chainId: ChainId): Client {
+  const baseUrl = API_URLS[chainId];
+
+  function constructRequest(...params: unknown[]) {
+    try {
+      return { ...baseOptions, body: JSON.stringify([...params]) };
+    } catch (e) {
+      throw new Error(`Could not stringify ${params}`);
+    }
   }
-}
 
-export async function request<T>(
-  method: string,
-  ...params: unknown[]
-): Promise<T> {
-  const response = await fetch(
-    `${baseUrl}/${method}`,
-    constructRequest(...params)
+  async function request<T>(method: string, ...params: unknown[]): Promise<T> {
+    const response = await fetch(
+      `${baseUrl}/${method}`,
+      constructRequest(...params)
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        JSON.stringify({
+          status: response.status,
+          message: response.statusText,
+        })
+      );
+    }
+    return response.json();
+  }
+
+  const getLatestTvl: GetStat = (address) =>
+    address ? request("global/tvl", address) : request("global/globalTvl");
+  const getLatestTvm: GetStat = (address) =>
+    address ? request("global/tvm", address) : request("global/globalTvm");
+  const getTvl: GetStatBetween = (
+    address,
+    startTimestamp = Math.floor(time90DaysAgo().toSeconds())
+  ) => request("tvlHistoryBetween", address, startTimestamp);
+
+  // FIXME: This the bot price, not the last traded price. Needs to be handled API side.
+  const getYesterdayPrice: GetPriceSlice = (address: string) =>
+    request(
+      "sliceHistoricalSynthPrices",
+      address,
+      Math.floor(oneDayAgo().toSeconds())
+    );
+
+  const getAddresses: GetAddresses = async () => {
+    const empAddresses: string[] = await request("listEmpAddresses");
+    const lspAddresses: string[] = await request("listAddresses");
+    return [...empAddresses, ...lspAddresses];
+  };
+
+  const getState: GetState = async <T extends { type: ContractType }>(
+    address: string
+  ) => {
+    const state: SynthState<T> = await request("global/getState", address);
+    return state;
+  };
+
+  const getSynthStats: GetSynthStats = async (address) => {
+    return {
+      id: address,
+      address,
+      tvl: await getLatestTvl(address).catch(() => "0"),
+      tvm: await getLatestTvm(address).catch(() => "0"),
+    };
+  };
+
+  async function fetchCompleteSynth<T extends { type: ContractType }>(
+    synth: ContentfulSynth
+  ): Promise<Synth<T> | Error> {
+    try {
+      const stats = await getSynthStats(synth.address);
+      const state = await getState<T>(synth.address);
+      const lastTvl = await getLatestTvl(synth.address).catch(() => "0");
+      const [{ value: ydayTvl = NaN } = {}] = await request(
+        "global/tvlHistorySlice",
+        synth.address,
+        Math.floor(oneDayAgo().toSeconds())
+      );
+      const tvl24hChange = !Number.isNaN(ydayTvl)
+        ? Math.round(
+            ((formatWeiString(lastTvl) - formatWeiString(ydayTvl)) /
+              formatWeiString(ydayTvl)) *
+              1000
+          ) / 10
+        : 0;
+
+      return {
+        ...stats,
+        ...state,
+        tvl24hChange,
+        ...synth,
+      };
+    } catch (err) {
+      return new SynthFetchingError(err.message, synth);
+    }
+  }
+
+  const client = {
+    request,
+    getAddresses,
+    getState,
+    getSynthStats,
+    getLatestTvl,
+    getLatestTvm,
+    getTvl,
+    getYesterdayPrice,
+    fetchCompleteSynth,
+  };
+
+  return client;
+}
+export const constructClient = memoize(_constructClient);
+
+export async function getGlobalTvm(): Promise<string> {
+  // TODO: should prob filter out errors here and only use prod chain ID
+
+  const tvms = await Promise.all(
+    (Object.keys(API_URLS) as unknown as ChainId[]).map((chainId) => {
+      return constructClient(chainId).getLatestTvm();
+    })
   );
 
-  if (!response.ok) {
-    throw new Error(
-      JSON.stringify({ status: response.status, message: response.statusText })
-    );
-  }
-  return response.json();
+  return tvms
+    .map((stringTvm) => BigNumber.from(stringTvm))
+    .reduce((acc: BigNumber, tvm: BigNumber) => acc.add(tvm), BigNumber.from(0))
+    .toString();
 }
 // Basic types
 interface EmpState {
@@ -130,6 +251,7 @@ export type TimeSeries = {
 }[];
 
 // Function types
+type RequestFn = <T>(method: string, ...params: unknown[]) => Promise<T>;
 type GetAddresses = () => Promise<string[]>;
 type GetState = <T extends { type: ContractType }>(
   address: string
@@ -144,91 +266,18 @@ type GetStatBetween = (
 ) => Promise<SynthStats[]>;
 
 type GetPriceSlice = (address: string) => Promise<string[]>;
-
-const getAddresses: GetAddresses = async () => {
-  const empAddresses: string[] = await request("listEmpAddresses");
-  const lspAddresses: string[] = await request("listAddresses");
-  return [...empAddresses, ...lspAddresses];
-};
-
-const getState: GetState = async <T extends { type: ContractType }>(
-  address: string
-) => {
-  const state: SynthState<T> = await request("global/getState", address);
-  return state;
-};
-
-const getSynthStats: GetSynthStats = async (address) => {
-  return {
-    id: address,
-    address,
-    tvl: await getLatestTvl(address).catch(() => "0"),
-    tvm: await getLatestTvm(address).catch(() => "0"),
-  };
-};
-
-const time90DaysAgo = nDaysAgo(90);
-const oneDayAgo = nDaysAgo(1);
-
-const getLatestTvl: GetStat = (address) =>
-  address ? request("global/tvl", address) : request("global/globalTvl");
-const getLatestTvm: GetStat = (address) =>
-  address ? request("global/tvm", address) : request("global/globalTvm");
-const getTvl: GetStatBetween = (
-  address,
-  startTimestamp = Math.floor(time90DaysAgo().toSeconds())
-) => request("tvlHistoryBetween", address, startTimestamp);
-
-// FIXME: This the bot price, not the last traded price. Needs to be handled API side.
-const getYesterdayPrice: GetPriceSlice = (address: string) =>
-  request(
-    "sliceHistoricalSynthPrices",
-    address,
-    Math.floor(oneDayAgo().toSeconds())
-  );
-export const client = {
-  request,
-  getAddresses,
-  getState,
-  getSynthStats,
-  getLatestTvl,
-  getLatestTvm,
-  getTvl,
-  getYesterdayPrice,
-};
-
-export async function fetchCompleteSynth<T extends { type: ContractType }>(
+type FetchCompleteSynth = <T extends { type: ContractType }>(
   synth: ContentfulSynth
-): Promise<Synth<T> | Error> {
-  try {
-    const stats = await client.getSynthStats(synth.address);
-    const state = await client.getState<T>(synth.address);
-    const lastTvl = await client.getLatestTvl(synth.address).catch(() => "0");
-    const [{ value: ydayTvl = NaN } = {}] = await client.request(
-      "global/tvlHistorySlice",
-      synth.address,
-      Math.floor(oneDayAgo().toSeconds())
-    );
-    const tvl24hChange = !Number.isNaN(ydayTvl)
-      ? Math.round(
-          ((formatWeiString(lastTvl) - formatWeiString(ydayTvl)) /
-            formatWeiString(ydayTvl)) *
-            1000
-        ) / 10
-      : 0;
+) => Promise<Synth<T> | Error>;
 
-    return {
-      ...stats,
-      ...state,
-      tvl24hChange,
-      ...synth,
-    };
-  } catch (err) {
-    return new SynthFetchingError(err.message, synth);
-  }
-}
-
-// longTokenName can return undefined if value wasn't found in API so we need to do a null check.
-export function formatLSPName(longTokenName: string): string {
-  return longTokenName?.substring(-2);
-}
+type Client = {
+  request: RequestFn;
+  getAddresses: GetAddresses;
+  getState: GetState;
+  getSynthStats: GetSynthStats;
+  getLatestTvl: GetStat;
+  getLatestTvm: GetStat;
+  getTvl: GetStatBetween;
+  getYesterdayPrice: GetPriceSlice;
+  fetchCompleteSynth: FetchCompleteSynth;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,6 +6303,13 @@ axios@^0.21.4:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -11474,6 +11481,11 @@ follow-redirects@^1.14.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+
+follow-redirects@^1.14.4:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
**Motivation**
This PR refactors the API Client and the Contentful client to accept chain Id as parameter.

**Details** 
The changes to the Contentful client are minimal, an additional `getSynthsByChain` has been added.

In the API client some things have changed:
- There is now a function called `constructClient` which will take in a ChainId and give back a `Client` object. This fn is memoized for performance, so it won't reinstantiate an existing client if called twice.
- `fetchCompleteSynths` has been moved inside the client
- a `fetchGlobalTvm` function has been added to fetch TVM across all clients. The function is imperfect, as it should not fetch from the same URL twice, and it should filter out errors instead of failing completely. It requires more work but I didn't want to block progress on this, so it will be addressed in a future PR

Signed-off-by: Gamaranto <francesco@umaproject.org>