### PR TITLE
fix: Remove TVM from UMAverse and adjust boxes

### DIFF
--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -65,7 +65,7 @@ const Name: React.FC<NameProps> = ({ synth }) => {
   return (
     <NameWrapper>
       <ImageWrapper>
-        <Image src={formattedUrl} width="52" height="52" layout="fixed" />
+        <StyledImage src={formattedUrl} width="52" height="52" layout="fixed" />
       </ImageWrapper>
       <div>
         <NameHeading>{heading}</NameHeading>
@@ -81,10 +81,16 @@ const NameWrapper = styled.div`
 const ImageWrapper = styled.div`
   display: none;
   align-self: center;
+  height: 52px;
   @media ${QUERIES.tabletAndUp} {
     display: revert;
     margin-right: 25px;
   }
+`;
+const StyledImage = styled(Image)`
+  display: block;
+  margin-top: auto;
+  margin-bottom: auto;
 `;
 const NameHeading = styled.h6`
   font-weight: bold;

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -80,6 +80,7 @@ const NameWrapper = styled.div`
 `;
 const ImageWrapper = styled.div`
   display: none;
+  align-self: center;
   @media ${QUERIES.tabletAndUp} {
     display: revert;
     margin-right: 25px;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -126,10 +126,7 @@ const IndexPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <Heading>
           Explore the <span>UMA</span>verse
         </Heading>
-        <Description>
-          UMA — a fast, flexible, and secure protocol for decentralized
-          financial products
-        </Description>
+        <Description>UMA — The optimistic oracle built for Web3</Description>
         <CardWrapper>
           <Card>
             <CardContent>
@@ -244,4 +241,5 @@ const Description = styled.span`
   text-align: center;
   font-size: ${20 / 16}rem;
   display: block;
+  margin-bottom: ${16 / 16}rem;
 `;


### PR DESCRIPTION
Story details: https://app.shortcut.com/uma-project/story/444

Icons centered in of row in rable
<img width="696" alt="Screen Shot 2022-02-08 at 11 24 11 AM" src="https://user-images.githubusercontent.com/12792146/153060508-08a7bfb2-f66e-4ada-9a9c-b9835aa60b50.png">

Adjust margin of text and copy.
<img width="1393" alt="Screen Shot 2022-02-08 at 11 24 00 AM" src="https://user-images.githubusercontent.com/12792146/153060505-aead0223-324a-47b5-acb6-90fb15c637ae.png">
7