### PR TITLE
fix: prevent parse to eth error

### DIFF
--- a/components/EmpHero.tsx
+++ b/components/EmpHero.tsx
@@ -21,7 +21,7 @@ export const EmpHero: React.FC<Props> = ({ synth, change24h }) => {
             Total Value Locked <span>(TVL)</span>
           </CardHeading>
           <Value
-            value={synth.tvl}
+            value={synth.tvl || "0"}
             format={(v) => {
               const formattedValue = formatWeiString(v);
               return (

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -172,7 +172,7 @@ const columns = [
     Header: "TVL",
     id: "tvl",
     accessor: (row) => {
-      const parsedTvl = formatWeiString(row.tvl);
+      const parsedTvl = row.tvl ? formatWeiString(row.tvl) : 0;
       const postFix =
         parsedTvl >= 10 ** 9 ? "B" : parsedTvl >= 10 ** 6 ? "M" : "";
       return `$${formatMillions(Math.floor(parsedTvl))} ${postFix}`;
@@ -230,7 +230,10 @@ const SET_GLOBAL_FILTER_ACTION = "setGlobalFilter";
 
 export const Table: React.FC<Props> = ({ data, hasFilters = true }) => {
   const tableData = useMemo(
-    () => data.sort((a, b) => formatWeiString(b.tvl) - formatWeiString(a.tvl)),
+    () =>
+      data.sort(
+        (a, b) => formatWeiString(b.tvl || "0") - formatWeiString(a.tvl || "0")
+      ),
     [data]
   );
   const filterTypes = React.useMemo(

--- a/pages/[chain]/[address].tsx
+++ b/pages/[chain]/[address].tsx
@@ -171,7 +171,10 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
       data,
       chainId: cmsSynth.chainId,
       relatedSynths: relatedSynths
-        .sort((a, b) => formatWeiString(b.tvl) - formatWeiString(a.tvl))
+        .sort(
+          (a, b) =>
+            formatWeiString(b.tvl || "0") - formatWeiString(a.tvl || "0")
+        )
         .slice(0, 5),
       dehydratedState: dehydrate(queryClient),
     },

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -37,7 +37,7 @@ export function capitalize(s: string): string {
 }
 
 export function formatWeiString(v: ethers.BigNumberish): number {
-  return Number(ethers.utils.formatEther(v));
+  return v ? Number(ethers.utils.formatEther(v)) : 0;
 }
 
 export function formatTvlChange(

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -37,7 +37,7 @@ export function capitalize(s: string): string {
 }
 
 export function formatWeiString(v: ethers.BigNumberish): number {
-  return v ? Number(ethers.utils.formatEther(v)) : 0;
+  return Number(ethers.utils.formatEther(v));
 }
 
 export function formatTvlChange(

--- a/utils/umaApi.ts
+++ b/utils/umaApi.ts
@@ -236,7 +236,7 @@ export type SynthState<T extends { type: ContractType }> = T extends {
 export type SynthStats = {
   id: string;
   address: string;
-  tvl: string;
+  tvl?: string;
   tvm: string;
 };
 export type Synth<T extends { type: ContractType }> = ContentfulSynth &


### PR DESCRIPTION
Make FE more resilient in case API's tvl field is missing for contracts