### PR TITLE
fix: consider decimals when calculating amounts

### DIFF
--- a/components/lsp/Collateral.tsx
+++ b/components/lsp/Collateral.tsx
@@ -95,8 +95,10 @@ const Collateral: FC<Props> = ({
           {(collateralOnTop || !redeemForm) && (
             <span
               onClick={() => {
-                const normalizedBalance =
-                  ethers.utils.formatEther(collateralBalance);
+                const normalizedBalance = ethers.utils.formatUnits(
+                  collateralBalance,
+                  collateralDecimals
+                );
                 setAmount(normalizedBalance);
 
                 setLongShortPairInputs(normalizedBalance);

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -148,7 +148,7 @@ const MintForm: FC<Props> = ({
       }
 
       if (amount) {
-        const weiAmount = toWeiSafe(amount);
+        const weiAmount = toWeiSafe(amount, Number(collateralDecimals));
         try {
           // Need to send the correct amount based on the collateral pair ** the amount
           // User has specified in the input.


### PR DESCRIPTION
The token amounts calculated for minting and clicking the `Max` button are incorrect because the number of decimals is not taken into consideration