### PR TITLE
fix: reset form inputs after tx is confirmed

### DIFF
--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -154,22 +154,17 @@ const MintForm: FC<Props> = ({
           // User has specified in the input.
           // All operations that make the number larger come first. All the operations that make the number smaller come last.
           const mintAmount = weiAmount.mul(scaledToWei).div(collateralPerPair);
-          lspContract
-            .create(mintAmount)
-            .then((tx: any) => {
-              setAmount("");
-              setLongTokenAmount("");
-              setShortTokenAmount("");
-              return tx.wait(1);
-            })
-            .then(async () => {
-              const balance = (await collateralERC20Contract.balanceOf(
-                address
-              )) as ethers.BigNumber;
-              setCollateralBalance(balance);
-              refetchLongTokenBalance();
-              refetchShortTokenBalance();
-            });
+          const tx = await lspContract.create(mintAmount);
+          await tx.wait(1);
+          setAmount("");
+          setLongTokenAmount("");
+          setShortTokenAmount("");
+          const balance = (await collateralERC20Contract.balanceOf(
+            address
+          )) as ethers.BigNumber;
+          setCollateralBalance(balance);
+          refetchLongTokenBalance();
+          refetchShortTokenBalance();
         } catch (err) {
           console.log("err", err);
         }
@@ -188,13 +183,13 @@ const MintForm: FC<Props> = ({
     userNeedsToApprove,
   ]);
 
-  if (web3Provider && !isUserConnectedToContractChain) {
-    return (
-      <SwitchWalletContainer>
-        <SwitchWalletLsp targetChainId={chainId} />
-      </SwitchWalletContainer>
-    );
-  }
+  // if (web3Provider && !isUserConnectedToContractChain) {
+  //   return (
+  //     <SwitchWalletContainer>
+  //       <SwitchWalletLsp targetChainId={chainId} />
+  //     </SwitchWalletContainer>
+  //   );
+  // }
 
   return (
     <div>

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -183,13 +183,13 @@ const MintForm: FC<Props> = ({
     userNeedsToApprove,
   ]);
 
-  // if (web3Provider && !isUserConnectedToContractChain) {
-  //   return (
-  //     <SwitchWalletContainer>
-  //       <SwitchWalletLsp targetChainId={chainId} />
-  //     </SwitchWalletContainer>
-  //   );
-  // }
+  if (web3Provider && !isUserConnectedToContractChain) {
+    return (
+      <SwitchWalletContainer>
+        <SwitchWalletLsp targetChainId={chainId} />
+      </SwitchWalletContainer>
+    );
+  }
 
   return (
     <div>

--- a/components/lsp/RedeemForm.tsx
+++ b/components/lsp/RedeemForm.tsx
@@ -113,22 +113,17 @@ const RedeemForm: FC<Props> = ({
       // It should be noted too, as you can have more of one than the other, we need to make sure the user is not trying to redeem more tokens than they have of the matching pair.
       const weiAmount = toWeiSafe(longTokenAmount, Number(collateralDecimals));
       try {
-        await lspContract
-          .redeem(weiAmount)
-          .then((tx: any) => {
-            setAmount("");
-            setLongTokenAmount("");
-            setShortTokenAmount("");
-            return tx.wait(1);
-          })
-          .then(async () => {
-            const balance = (await collateralERC20Contract.balanceOf(
-              address
-            )) as ethers.BigNumber;
-            setCollateralBalance(balance);
-            refetchLongTokenBalance();
-            refetchShortTokenBalance();
-          });
+        const tx = await lspContract.redeem(weiAmount);
+        await tx.wait(1);
+        setAmount("");
+        setLongTokenAmount("");
+        setShortTokenAmount("");
+        const balance = (await collateralERC20Contract.balanceOf(
+          address
+        )) as ethers.BigNumber;
+        setCollateralBalance(balance);
+        refetchLongTokenBalance();
+        refetchShortTokenBalance();
       } catch (err) {
         console.log("err", err);
       }


### PR DESCRIPTION
Reset LSP form inputs only after tx is confirmed

[Issue here](https://app.shortcut.com/uma-project/story/4578/when-redeeming-i-enter-in-a-value-to-redeem-and-submit-a-tx-but-once-i-click-redeem-the-input-values-i-entered-are-cleared)