### PR TITLE
fix: call api client method explicitly inside map cb

### DIFF
--- a/utils/contentful.ts
+++ b/utils/contentful.ts
@@ -98,7 +98,9 @@ async function getRelatedSynths(
   // Get the synths state to see if they're expired or not
   const allRelatedSynths = (
     await Promise.all(
-      relatedCmsSynths.map(constructClient(synth.chainId).fetchCompleteSynth)
+      relatedCmsSynths.map((synth) =>
+        constructClient(synth.chainId).fetchCompleteSynth(synth)
+      )
     )
   ).filter(errorFilter) as Synth<{ type: ContractType }>[];
   const relevantRelatedSynths = allRelatedSynths.filter((relatedSynth) => {

--- a/utils/contentful.ts
+++ b/utils/contentful.ts
@@ -98,9 +98,7 @@ async function getRelatedSynths(
   // Get the synths state to see if they're expired or not
   const allRelatedSynths = (
     await Promise.all(
-      relatedCmsSynths.map((synth) =>
-        constructClient(synth.chainId).fetchCompleteSynth(synth)
-      )
+      relatedCmsSynths.map(constructClient(synth.chainId).fetchCompleteSynth)
     )
   ).filter(errorFilter) as Synth<{ type: ContractType }>[];
   const relevantRelatedSynths = allRelatedSynths.filter((relatedSynth) => {

--- a/utils/umaApi.ts
+++ b/utils/umaApi.ts
@@ -48,7 +48,7 @@ class Client implements IClient {
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
   }
-  async request<T>(method: string, ...params: unknown[]): Promise<T> {
+  request = async <T>(method: string, ...params: unknown[]): Promise<T> => {
     const response = await fetch(
       `${this.baseUrl}/${method}`,
       constructRequest(...params)
@@ -63,7 +63,7 @@ class Client implements IClient {
       );
     }
     return response.json();
-  }
+  };
 
   getLatestTvl: GetStat = (address) =>
     address
@@ -106,9 +106,9 @@ class Client implements IClient {
     };
   };
 
-  async fetchCompleteSynth<T extends { type: ContractType }>(
+  fetchCompleteSynth = async <T extends { type: ContractType }>(
     synth: ContentfulSynth
-  ): Promise<Synth<T> | Error> {
+  ): Promise<Synth<T> | Error> => {
     try {
       const stats = await this.getSynthStats(synth.address);
       const state = await this.getState<T>(synth.address);
@@ -135,7 +135,7 @@ class Client implements IClient {
     } catch (err) {
       return new SynthFetchingError(err.message, synth);
     }
-  }
+  };
 }
 
 function _constructClient(chainId: ChainId): Client {


### PR DESCRIPTION
Issue: Related contracts don't appear on the bottom of the contract page

This is just a one line fix, but took me a while to figure out what the problem was. ["this" execution context](https://github.com/UMAprotocol/umaverse/blob/master/utils/umaApi.ts#L113) was `undefined` inside `fetchCompleteSynth` method. This is some JS specific behaviour, but most probably when `map` calls the callback function, it causes the `fetchCompleteSynth` method to lose its initial execution context. I refactored the Client's methods to arrow functions