### PR TITLE
fix: allow configurable confirmations and testnet

### DIFF
--- a/components/LineChart.tsx
+++ b/components/LineChart.tsx
@@ -39,13 +39,8 @@ export const LineChart: React.FC<ChartProps> = ({
   data,
   onDataHover,
 }) => {
-  const {
-    showTooltip,
-    hideTooltip,
-    tooltipData,
-    tooltipTop,
-    tooltipLeft,
-  } = useTooltip<TimeSeriesEntry>();
+  const { showTooltip, hideTooltip, tooltipData, tooltipTop, tooltipLeft } =
+    useTooltip<TimeSeriesEntry>();
   // define the scales. This is necessary because timeseries need to be converted to pixel values
   const dateScale = useMemo(
     () =>

--- a/components/LspHero.tsx
+++ b/components/LspHero.tsx
@@ -10,6 +10,7 @@ import { useConnection, useOnboard } from "../hooks";
 import UnstyledWalletIcon from "../public/icons/wallet.svg";
 import { ethers } from "ethers";
 import { SwitchWalletLsp } from "./lsp/SwitchWalletLsp";
+import { TEST_CHAIN_ID } from "utils/constants";
 
 type Props = {
   synth: Synth<{ type: "lsp" }>;
@@ -36,7 +37,11 @@ export const LspHero: React.FC<Props> = ({
     }
   }, [initOnboard, isConnected, resetOnboard]);
   const hasToChangeChain = useMemo(() => {
-    return connectionChainId && connectionChainId !== chainId;
+    return (
+      connectionChainId &&
+      connectionChainId !== TEST_CHAIN_ID &&
+      connectionChainId !== chainId
+    );
   }, [connectionChainId, chainId]);
 
   return (

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -84,8 +84,7 @@ const MintForm: FC<Props> = ({
   const isUserConnectedToContractChain = useMemo(() => {
     return (
       !!connectionChainId &&
-      (Number(connectionChainId) === TEST_CHAIN_ID ||
-        connectionChainId === chainId)
+      (connectionChainId === TEST_CHAIN_ID || connectionChainId === chainId)
     );
   }, [connectionChainId, chainId]);
   const getKnownAllowance = useCallback(() => {

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -14,6 +14,7 @@ import { faArrowDown } from "@fortawesome/free-solid-svg-icons";
 import { ethers, BigNumber } from "ethers";
 import toWeiSafe from "../../utils/convertToWeiSafely";
 import { useConnection } from "../../hooks";
+import { TEST_CHAIN_ID, CONFIRMATIONS } from "utils/constants";
 
 import LongShort from "./LongShort";
 import Collateral from "./Collateral";
@@ -81,7 +82,11 @@ const MintForm: FC<Props> = ({
     BigNumber.from(0)
   );
   const isUserConnectedToContractChain = useMemo(() => {
-    return !!connectionChainId && connectionChainId === chainId;
+    return (
+      !!connectionChainId &&
+      (Number(connectionChainId) === TEST_CHAIN_ID ||
+        connectionChainId === chainId)
+    );
   }, [connectionChainId, chainId]);
   const getKnownAllowance = useCallback(() => {
     if (!collateralERC20Contract || !address || !contractAddress) return;
@@ -140,7 +145,7 @@ const MintForm: FC<Props> = ({
           );
 
           // update our known allowance once approval passes
-          return approveTx.wait(1).then(() => getKnownAllowance());
+          return approveTx.wait(CONFIRMATIONS).then(() => getKnownAllowance());
         }
       } catch (err) {
         console.log("err in approval check", err);
@@ -155,7 +160,7 @@ const MintForm: FC<Props> = ({
           // All operations that make the number larger come first. All the operations that make the number smaller come last.
           const mintAmount = weiAmount.mul(scaledToWei).div(collateralPerPair);
           const tx = await lspContract.create(mintAmount);
-          await tx.wait(1);
+          await tx.wait(CONFIRMATIONS);
           setAmount("");
           setLongTokenAmount("");
           setShortTokenAmount("");

--- a/components/lsp/RedeemForm.tsx
+++ b/components/lsp/RedeemForm.tsx
@@ -9,6 +9,7 @@ import {
   LSPFormError,
   SwitchWalletContainer,
 } from "./LSP.styled";
+import { TEST_CHAIN_ID, CONFIRMATIONS } from "utils/constants";
 import { ethers } from "ethers";
 import LongShort from "./LongShort";
 import Collateral from "./Collateral";
@@ -68,7 +69,11 @@ const RedeemForm: FC<Props> = ({
 
   const { signer, chainId: connectionChainId } = useConnection();
   const hasToSwitchChain = useMemo(() => {
-    if (signer && connectionChainId !== chainId) {
+    if (
+      signer &&
+      connectionChainId !== TEST_CHAIN_ID &&
+      connectionChainId !== chainId
+    ) {
       return true;
     }
     return false;
@@ -125,7 +130,7 @@ const RedeemForm: FC<Props> = ({
       const weiAmount = toWeiSafe(longTokenAmount, Number(collateralDecimals));
       try {
         const tx = await lspContract.redeem(weiAmount);
-        await tx.wait(1);
+        await tx.wait(CONFIRMATIONS);
         setAmount("");
         setLongTokenAmount("");
         setShortTokenAmount("");

--- a/pages/[chain]/[address].tsx
+++ b/pages/[chain]/[address].tsx
@@ -185,12 +185,14 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 export const getStaticPaths: GetStaticPaths = async () => {
   const allCmsSynths = await contentfulClient.getAllSynths();
 
-  const paths = allCmsSynths.map((synth) => ({
-    params: {
-      address: synth.address,
-      chain: chainIdToNameLookup[synth.chainId],
-    },
-  }));
+  const paths = allCmsSynths
+    .filter((synth) => !!chainIdToNameLookup[synth.chainId])
+    .map((synth) => ({
+      params: {
+        address: synth.address,
+        chain: chainIdToNameLookup[synth.chainId],
+      },
+    }));
 
   return {
     paths,

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,5 +1,10 @@
 import { Initialization } from "bnc-onboard/dist/src/interfaces";
 
+export const TEST_CHAIN_ID = Number(
+  process.env.NEXT_PUBLIC_TEST_CHAIN_ID || 1337
+);
+export const CONFIRMATIONS = Number(process.env.NEXT_PUBLIC_CONFIRMATIONS || 1);
+
 export const BREAKPOINTS = {
   tabletMin: 550,
   laptopMin: 1100,


### PR DESCRIPTION
This lets us delay refetches after a transaction by adjusting confirmation times. They were hardcoded to 1 before, but we might want to increase that as sometimes fetching balances are not updated immediately after tx. For testing i've disabled the change chain dialogs only when on a testnet chain id.