### PR TITLE
fix: settle no longer clickable when disabled

### DIFF
--- a/components/lsp/LSP.styled.tsx
+++ b/components/lsp/LSP.styled.tsx
@@ -141,7 +141,7 @@ export const ButtonWrapper = styled.div`
 `;
 
 interface ILSPButton {
-  showDisabled?: boolean;
+  disabled?: boolean;
 }
 
 export const MintButton = styled(BaseButton)<ILSPButton>`
@@ -154,7 +154,7 @@ export const MintButton = styled(BaseButton)<ILSPButton>`
   font-family: inherit;
   padding: 0.75rem 0;
   width: 100%;
-  opacity: ${(props) => (props.showDisabled ? "0.5" : "1")};
+  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
   @media ${QUERIES.laptopAndUp} {
     width: 370px;
   }
@@ -179,8 +179,8 @@ export const SettleButton = styled(BaseButton)<ILSPButton>`
   font-weight: 600;
   font-family: inherit;
   padding: 0.66rem 0;
-  opacity: ${(props) => (props.showDisabled ? "0.5" : "1")};
-  cursor: ${(props) => (props.showDisabled ? "not-allowed" : "pointer")};
+  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
+  cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
   @media ${QUERIES.laptopAndUp} {
     width: 380px;
   }

--- a/components/lsp/LSP.styled.tsx
+++ b/components/lsp/LSP.styled.tsx
@@ -140,11 +140,7 @@ export const ButtonWrapper = styled.div`
   padding: 1rem;
 `;
 
-interface ILSPButton {
-  disabled?: boolean;
-}
-
-export const MintButton = styled(BaseButton)<ILSPButton>`
+export const MintButton = styled(BaseButton)`
   background-color: var(--primary, 500);
   color: var(--white);
   text-align: center;
@@ -154,9 +150,12 @@ export const MintButton = styled(BaseButton)<ILSPButton>`
   font-family: inherit;
   padding: 0.75rem 0;
   width: 100%;
-  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
   @media ${QUERIES.laptopAndUp} {
     width: 370px;
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 
@@ -168,7 +167,7 @@ export const SettleWrapper = styled.div`
   background: var(--gray-300);
 `;
 
-export const SettleButton = styled(BaseButton)<ILSPButton>`
+export const SettleButton = styled(BaseButton)`
   width: 90%;
   margin: 0 auto;
   background-color: #ff4b4b;
@@ -179,10 +178,12 @@ export const SettleButton = styled(BaseButton)<ILSPButton>`
   font-weight: 600;
   font-family: inherit;
   padding: 0.66rem 0;
-  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
-  cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
   @media ${QUERIES.laptopAndUp} {
     width: 380px;
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 

--- a/components/lsp/LSPForm.tsx
+++ b/components/lsp/LSPForm.tsx
@@ -197,7 +197,7 @@ const LSPForm: FC<Props> = ({
           )}
           <SettleButton
             id="settleButton"
-            showDisabled={settleButtonDisabled}
+            disabled={settleButtonDisabled}
             onClick={() => {
               // On click function only works when open or final price received.
               if (contractState === ContractState.Open) return expire();

--- a/components/lsp/MintForm.tsx
+++ b/components/lsp/MintForm.tsx
@@ -234,7 +234,7 @@ const MintForm: FC<Props> = ({
           <ButtonWrapper>
             <MintButton
               id="mintButton"
-              showDisabled={!signer || !!showMintError || Number(amount) <= 0}
+              disabled={!signer || !!showMintError || Number(amount) <= 0}
               onClick={() => {
                 if (showMintError) return false;
                 if (signer) {

--- a/components/lsp/RedeemForm.tsx
+++ b/components/lsp/RedeemForm.tsx
@@ -204,7 +204,7 @@ const RedeemForm: FC<Props> = ({
           <ButtonWrapper>
             <MintButton
               id="redeemButton"
-              showDisabled={!signer || showRedeemError ? true : false}
+              disabled={!signer || showRedeemError ? true : false}
               onClick={() => {
                 if (showRedeemError) return false;
                 if (signer) {

--- a/pages/[chain]/[address].tsx
+++ b/pages/[chain]/[address].tsx
@@ -348,7 +348,7 @@ const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
           contractAddress={data.address}
           isExpired={isExpired}
         />
-        {data.type === "emp" ? (
+        {freshData && data.type === "emp" ? (
           <EmpHero
             synth={freshData as Synth<{ type: "emp" }>}
             change24h={change24h ?? 0}
@@ -366,7 +366,9 @@ const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
       <MainWrapper>
         <div>
           <About description={data.description} />
-          <Information synth={freshData as Synth<{ type: ContractType }>} />
+          {freshData && (
+            <Information synth={freshData as Synth<{ type: ContractType }>} />
+          )}
         </div>
         <AsideWrapper>
           {data.type === "emp" && (


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Previously settle button was clickable when disabled, triggering a metamask transaction when clicked.  This is because rather than using the `disabled` prop, we used `showDisabled` which does not actually disable button events. 

This also happened to affect the mint button, so this change also fixes that button