### PR TITLE
fix: use pairName instead of longTokenName on lsp details

### DIFF
--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -25,7 +25,9 @@ export const Information: React.FC<Props> = ({ synth, className }) => {
         <Row>
           <div>Name:</div>
           <div>
-            {synth.type == "emp" ? synth.tokenName : synth.longTokenName}
+            {synth.type == "emp"
+              ? synth.tokenName
+              : synth.pairName || synth.longTokenName}
           </div>
         </Row>
         {synth.type == "emp" ? (

--- a/pages/[chain]/[address].tsx
+++ b/pages/[chain]/[address].tsx
@@ -200,19 +200,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-type Props =
-  | {
-      data: Synth<{ type: "emp" }>;
-      relatedSynths: Synth<{ type: ContractType }>[];
-      change24h: number;
-      chainId: ChainId;
-    }
-  | {
-      data: Synth<{ type: "lsp" }>;
-      relatedSynths: Synth<{ type: ContractType }>[];
-      change24h: number;
-      chainId: ChainId;
-    };
+interface Props {
+  data: Synth<{ type: "emp" }> | Synth<{ type: "lsp" }>;
+  relatedSynths: Synth<{ type: ContractType }>[];
+  change24h: number;
+  chainId: ChainId;
+}
 
 const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
   const { account = "", signer, isConnected } = useConnection();
@@ -220,6 +213,7 @@ const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
     ? formatContentfulUrl(data.logo.fields.file.url)
     : null;
 
+  console.log("synth data", data);
   const client = constructClient(chainId);
 
   const { data: synthState } = useQuery(

--- a/pages/[chain]/[address].tsx
+++ b/pages/[chain]/[address].tsx
@@ -213,7 +213,6 @@ const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
     ? formatContentfulUrl(data.logo.fields.file.url)
     : null;
 
-  console.log("synth data", data);
   const client = constructClient(chainId);
 
   const { data: synthState } = useQuery(
@@ -333,7 +332,7 @@ const SynthPage: React.FC<Props> = ({ data, chainId, relatedSynths }) => {
             <Heading>
               {data.type === "emp"
                 ? data.tokenName
-                : formatLSPName(data.longTokenName || "")}
+                : formatLSPName(data.pairName || data.longTokenName || "")}
             </Heading>
           </div>
         </HeroContentWrapper>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,7 +16,6 @@ import {
 import {
   contentfulClient,
   formatMillions,
-  getGlobalTvm,
   QUERIES,
   errorFilter,
   ContentfulSynth,
@@ -76,11 +75,6 @@ export const getStaticProps: GetStaticProps = async () => {
   await queryClient.prefetchQuery(
     "total tvl",
     async () => await getDefillamaTvl()
-  );
-
-  await queryClient.prefetchQuery(
-    "total tvm",
-    async () => await getGlobalTvm()
   );
 
   await queryClient.prefetchQuery(


### PR DESCRIPTION
this just use pairName for the title and "name" fields in the details page. 
before
![image](https://user-images.githubusercontent.com/4429761/159774163-d25ecbe6-a6e7-4683-9bd3-f2c56d3d0d36.png)
![image](https://user-images.githubusercontent.com/4429761/159774199-182748f5-fcda-4f69-a846-01145e65e865.png)


after
![image](https://user-images.githubusercontent.com/4429761/159774290-151e54fe-c507-4ee5-8d25-c6b77934e2d3.png)
![image](https://user-images.githubusercontent.com/4429761/159774324-8bf03120-7d98-4259-827d-98615fa363de.png)

