### PR TITLE
fix: fix token info table

### DIFF
--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -139,23 +139,25 @@ const Row = styled.div`
   padding: 0 10px;
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
 
   @media ${QUERIES.tabletAndUp} {
     padding: 0 20px;
     align-items: baseline;
   }
   @media ${QUERIES.tabletAndUp} {
-    & > div {
-      flex: 1;
-    }
   }
   & > div:first-of-type {
     font-weight: bold;
     margin-right: 5px;
+    width: 160px;
+    flex-shrink: 0;
   }
   & > div:not(:first-of-type) {
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 420px;
+    flex-grow: 1;
   }
 `;
 
@@ -174,13 +176,15 @@ const Heading = styled.h3`
 `;
 
 const StyledDuplicateIcon = styled(DuplicateIcon)`
+  margin-left: 10px;
   color: var(--primary);
   width: 20px;
   height: 20px;
   cursor: pointer;
-  margin: auto;
 `;
 
 const Address = styled.div`
   word-break: break-all;
+  display: flex;
+  align-items: center;
 `;

--- a/components/Information.tsx
+++ b/components/Information.tsx
@@ -113,7 +113,7 @@ export const Information: React.FC<Props> = ({ synth, className }) => {
             </Row>
             <Row>
               <div>Unique Sponsors:</div>
-              <div>{synth.sponsors.length}</div>
+              <div>{synth.sponsors?.length || "-"}</div>
             </Row>
             <Row>
               <div>Minimum Sponsor Tokens:</div>


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

This PR improves the UI of the Token Information table by showing the address on a single line and by aligning the Copy address button to be centered vertically

<img width="727" alt="Screenshot 2022-04-06 at 13 54 45" src="https://user-images.githubusercontent.com/89395931/161960378-9dbba000-d7f2-4d02-adc8-93054cdc2958.png">
